### PR TITLE
Allow templating in next steps

### DIFF
--- a/cmd/commands/init.go
+++ b/cmd/commands/init.go
@@ -86,7 +86,7 @@ func runInit(cmd *cobra.Command, args []string) {
 			// detect background color and pick either the default dark or light theme
 			glamour.WithAutoStyle(),
 		)
-		out, _ := renderer.Render(tpl.PostSetup)
+		out, _ := renderer.Render(tpl.TemplatedPostSetup(*fn))
 		fmt.Println(out)
 	}
 

--- a/pkg/function/function_test.go
+++ b/pkg/function/function_test.go
@@ -36,7 +36,7 @@ func TestDerivedConfigDefault(t *testing.T) {
 		Scopes: []string{"secret:read:*"},
 		Runtime: inngest.RuntimeWrapper{
 			Runtime: inngest.RuntimeDocker{
-				Image: "magical-id-1",
+				Image: "magical-id-1-action",
 			},
 		},
 	}
@@ -53,7 +53,7 @@ action: {
   name: "Foo"
   scopes: ["secret:read:*"]
   runtime: {
-    image: "magical-id-1"
+    image: "magical-id-1-action"
     type:  "docker"
   }
 }`

--- a/pkg/scaffold/template.go
+++ b/pkg/scaffold/template.go
@@ -32,6 +32,27 @@ type tplData struct {
 	EventTriggers []*function.EventTrigger
 }
 
+func (t Template) TemplatedPostSetup(f function.Function) string {
+	tpl, err := template.New("postsetup").Parse(string(t.PostSetup))
+	if err != nil {
+		return t.PostSetup
+	}
+
+	data := map[string]string{
+		"id":   f.ID,
+		"name": f.Name,
+		"slug": f.Slug(),
+		"dir":  f.Slug(),
+	}
+
+	buf := &bytes.Buffer{}
+	if err := tpl.Execute(buf, data); err != nil {
+		return t.PostSetup
+	}
+
+	return buf.String()
+}
+
 // Render renders the template and all files into the folder specified by function.
 func (t Template) Render(f function.Function) error {
 	dirname := f.Slug()


### PR DESCRIPTION
This passes the function ID, name, slug, and dir into postSetup for
templating, allowing us to show `cd into ./foo-bar-baz` post setup.