### PR TITLE
Fix nil pointer error if no workspace set

### DIFF
--- a/pkg/cli/initialize_fn.go
+++ b/pkg/cli/initialize_fn.go
@@ -525,7 +525,7 @@ func fetchEvents() ([]client.Event, error) {
 	defer done()
 
 	var workspaceID *uuid.UUID
-	if s, err := state.GetState(ctx); err == nil {
+	if s, err := state.GetState(ctx); err == nil && s.SelectedWorkspace != nil {
 		workspaceID = &s.SelectedWorkspace.ID
 	}
 


### PR DESCRIPTION
Following the first `inngest init` run (without logging in), I had a `~/.config/inngest/state` file that didn't contain a `workspace.id` key. This led to `cli.fetchEvents()` assuming a workspace existed and therefore throwing a nil pointer error on the second run of `inngest init`.

Is it sensible to catch this here or should `state.GetState()` be throwing an error in this case?

<details>
  <summary>Error</summary>

```
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x0 pc=0xe8e412]

goroutine 16 [running]:
github.com/inngest/inngestctl/pkg/cli.fetchEvents()
        /[redacted_path]/src/github.com/inngest/inngest-cli/pkg/cli/initialize_fn.go:533 +0xf2
github.com/inngest/inngestctl/pkg/cli.(*initModel).Init.func1()
        /[redacted_path]/src/github.com/inngest/inngest-cli/pkg/cli/initialize_fn.go:184 +0x26
github.com/charmbracelet/bubbletea.(*Program).StartReturningModel.func7.1()
        /[redacted_path]/src/github.com/inngest/inngest-cli/vendor/github.com/charmbracelet/bubbletea/tea.go:483 +0x51
created by github.com/charmbracelet/bubbletea.(*Program).StartReturningModel.func7
        /[redacted_path]/src/github.com/inngest/inngest-cli/vendor/github.com/charmbracelet/bubbletea/tea.go:481 +0x19b
exit status 2
```
</details>

<details>
  <summary>~/.config/state</summary>
  
```json
{
  "credentials": null,
  "account": {
    "id": "00000000-0000-0000-0000-000000000000",
    "name": "",
    "test": false,
    "identifier": {
      "dsnPrefix": "",
      "domain": null,
      "verifiedAt": null
    }
  },
  "settings": {
    "ranInit": true
  }
}
```
</details>