### PR TITLE
Default to `test` workspace, with `--prod` flag and env var overrides

### DIFF
--- a/cmd/commands/deploy.go
+++ b/cmd/commands/deploy.go
@@ -31,6 +31,8 @@ func NewCmdDeploy() *cobra.Command {
 }
 
 func doDeploy(cmd *cobra.Command, args []string) {
+	fmt.Println(cli.EnvString())
+
 	if err := deployFunction(cmd, args); err != nil {
 		fmt.Println("\n" + cli.RenderError(err.Error()) + "\n")
 		os.Exit(1)
@@ -60,7 +62,12 @@ func deployFunction(cmd *cobra.Command, args []string) error {
 }
 
 func deployWorkflow(ctx context.Context, fn *function.Function) error {
-	state := state.RequireState(ctx)
+	s := state.RequireState(ctx)
+
+	ws, err := state.Workspace(ctx)
+	if err != nil {
+		return err
+	}
 
 	wflow, err := fn.Workflow(ctx)
 	if err != nil {
@@ -73,7 +80,7 @@ func deployWorkflow(ctx context.Context, fn *function.Function) error {
 	}
 
 	fmt.Println(cli.BoldStyle.Render(fmt.Sprintf("Deploying workflow %s...", wflow.Name)))
-	v, err := state.Client.DeployWorkflow(ctx, state.SelectedWorkspace.ID, config, true)
+	v, err := s.Client.DeployWorkflow(ctx, ws.ID, config, true)
 	if err != nil {
 		return fmt.Errorf("failed to deploy workflow: %w", err)
 	}

--- a/cmd/commands/login.go
+++ b/cmd/commands/login.go
@@ -63,21 +63,10 @@ func NewCmdLogin() *cobra.Command {
 				os.Exit(1)
 			}
 
-			// Find their workspaces, and select the default workspace.
-			workspaces, err := client.Workspaces(ctx)
-			if err != nil {
-				log.From(ctx).Fatal().Msgf("unable to fetch workspaces: %s", err.Error())
-			}
-
+			// TODO: Create a new temporary PSK and use this instead of a JWT for credentials.
 			state := state.State{
 				Credentials: jwt,
 				Account:     *account,
-			}
-
-			for _, item := range workspaces {
-				if item.Name == "default" && !item.Test {
-					_ = state.SetWorkspace(ctx, item)
-				}
 			}
 
 			if err := state.Persist(ctx); err != nil {

--- a/cmd/commands/root.go
+++ b/cmd/commands/root.go
@@ -27,6 +27,8 @@ func Execute() {
 		Long:  longDescription,
 	}
 
+	rootCmd.PersistentFlags().Bool("prod", false, "Use the production environment for the current command.")
+
 	if err := viper.BindPFlags(rootCmd.PersistentFlags()); err != nil {
 		panic(err)
 	}

--- a/cmd/commands/util.go
+++ b/cmd/commands/util.go
@@ -14,14 +14,19 @@ import (
 
 // findWorkflow finds a workflow given a UUID or a UUID prefix.
 func findWorkflow(ctx context.Context, idOrPrefix string) (*client.Workflow, error) {
-	state := state.RequireState(ctx)
+	s := state.RequireState(ctx)
+
+	ws, err := state.Workspace(ctx)
+	if err != nil {
+		return nil, err
+	}
 
 	id, err := uuid.Parse(idOrPrefix)
 	if err == nil {
-		return state.Client.Workflow(ctx, state.SelectedWorkspace.ID, id)
+		return s.Client.Workflow(ctx, ws.ID, id)
 	}
 
-	flows, err := state.Client.Workflows(ctx, state.SelectedWorkspace.ID)
+	flows, err := s.Client.Workflows(ctx, ws.ID)
 	if err != nil {
 		log.From(ctx).Fatal().Err(err).Msg("unable to fetch workspaces")
 	}
@@ -43,7 +48,7 @@ func findWorkflow(ctx context.Context, idOrPrefix string) (*client.Workflow, err
 	}
 
 	if len(candidates) == 0 {
-		return nil, fmt.Errorf("No workflow in workspace '%s' found for ID: %s", state.SelectedWorkspace.Name, idOrPrefix)
+		return nil, fmt.Errorf("No workflow in workspace '%s' found for ID: %s", ws.Name, idOrPrefix)
 	}
 
 	return nil, fmt.Errorf("More than one workflow found with the prefix: %s", idOrPrefix)

--- a/cmd/commands/workspaces.go
+++ b/cmd/commands/workspaces.go
@@ -1,9 +1,7 @@
 package commands
 
 import (
-	"github.com/google/uuid"
 	"github.com/inngest/inngestctl/cmd/commands/internal/table"
-	"github.com/inngest/inngestctl/inngest/client"
 	"github.com/inngest/inngestctl/inngest/log"
 	"github.com/inngest/inngestctl/inngest/state"
 	"github.com/spf13/cobra"
@@ -23,49 +21,7 @@ func NewCmdWorkspaces() *cobra.Command {
 		Run:   listWorkspaces,
 	}
 
-	workspacesSelect := &cobra.Command{
-		Use:   "select",
-		Short: "Select a workspace for modification",
-		Run: func(cmd *cobra.Command, args []string) {
-			ctx := cmd.Context()
-			state := state.RequireState(ctx)
-
-			if len(args) == 0 {
-				log.From(ctx).Fatal().Msg("No workspace ID passed to select. Usage: workspaces select [ID]")
-			}
-
-			id, err := uuid.Parse(args[0])
-			if err != nil {
-				log.From(ctx).Fatal().Msg("Invalid workspace ID")
-			}
-
-			flows, err := state.Client.Workspaces(ctx)
-			if err != nil {
-				log.From(ctx).Fatal().Err(err).Msg("unable to fetch workspaces")
-			}
-
-			var found *client.Workspace
-			for _, f := range flows {
-				if f.ID == id {
-					found = &f
-					break
-				}
-			}
-
-			if found == nil {
-				log.From(ctx).Fatal().Msg("Workspace not found")
-			} else {
-				if err := state.SetWorkspace(ctx, *found); err != nil {
-					log.From(ctx).Fatal().Msgf("Error setting workspace: %s", err)
-				}
-			}
-
-			log.From(ctx).Info().Msg("Workspace selected")
-		},
-	}
-
 	workspacesRoot.AddCommand(workspacesList)
-	workspacesRoot.AddCommand(workspacesSelect)
 
 	return workspacesRoot
 }
@@ -79,20 +35,14 @@ func listWorkspaces(cmd *cobra.Command, args []string) {
 		log.From(ctx).Fatal().Err(err).Msg("unable to fetch workspaces")
 	}
 
-	t := table.New(table.Row{"Selected", "ID", "Name", "Type"})
+	t := table.New(table.Row{"ID", "Name", "Type"})
 	for _, f := range flows {
 		typ := "live"
 		if f.Test {
 			typ = "test"
 		}
 
-		selected := ""
-		if state.SelectedWorkspace != nil && state.SelectedWorkspace.ID == f.ID {
-			selected = "***"
-		}
-
 		t.AppendRow(table.Row{
-			selected,
 			f.ID,
 			f.Name,
 			typ,

--- a/pkg/cli/env.go
+++ b/pkg/cli/env.go
@@ -1,0 +1,31 @@
+package cli
+
+import (
+	"github.com/charmbracelet/lipgloss"
+	"github.com/inngest/inngestctl/inngest/state"
+)
+
+func EnvString() string {
+	prod := state.IsProd()
+
+	var env string
+	prefix := lipgloss.NewStyle().Bold(true).Padding(0, 1, 0, 0).Render("Environment:")
+
+	if prod {
+		env = lipgloss.NewStyle().
+			Background(Primary).
+			Foreground(White).
+			Bold(true).
+			Padding(0, 1).
+			Render("Production")
+	} else {
+		env = lipgloss.NewStyle().
+			Background(White).
+			Foreground(Black).
+			Bold(true).
+			Padding(0, 1).
+			Render("Test")
+	}
+
+	return prefix + env + "\n"
+}

--- a/pkg/cli/initialize_fn.go
+++ b/pkg/cli/initialize_fn.go
@@ -809,8 +809,8 @@ func fetchEvents() ([]client.Event, error) {
 	defer done()
 
 	var workspaceID *uuid.UUID
-	if s, err := state.GetState(ctx); err == nil && s.SelectedWorkspace != nil {
-		workspaceID = &s.SelectedWorkspace.ID
+	if w, err := state.Workspace(ctx); err == nil {
+		workspaceID = &w.ID
 	}
 
 	c := state.Client(ctx)

--- a/pkg/cli/styles.go
+++ b/pkg/cli/styles.go
@@ -8,6 +8,7 @@ var (
 	Green   = lipgloss.Color("#9dcc3a")
 	Red     = lipgloss.Color("#ff0000")
 	White   = lipgloss.Color("#ffffff")
+	Black   = lipgloss.Color("#000000")
 	Orange  = lipgloss.Color("#D3A347")
 
 	Feint     = lipgloss.AdaptiveColor{Light: "#333333", Dark: "#888888"}


### PR DESCRIPTION
This PR removes all notions of "selected" workspaces, removing workspace
statefulness across the CLI.

We now default to the test workspace for any command (eg. deploying
functions, viewing events).  This can be overridden with a global
`--prod` flag, or by setting one of the following environment variables
to "production" (in order of priority):

- `ENV`
- `NODE_ENV`
- `ENVIRONMENT`