### PR TITLE
Encode steps as map

### DIFF
--- a/inngest/action.go
+++ b/inngest/action.go
@@ -75,7 +75,7 @@ type RuntimeWrapper struct {
 	Runtime
 }
 
-func (r *RuntimeWrapper) MarshalJSON() ([]byte, error) {
+func (r RuntimeWrapper) MarshalJSON() ([]byte, error) {
 	return json.Marshal(r.Runtime)
 }
 

--- a/inngest/action_test.go
+++ b/inngest/action_test.go
@@ -1,0 +1,43 @@
+package inngest
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestMarshalRuntimeWrapper(t *testing.T) {
+	inputs := []struct {
+		name     string
+		r        RuntimeWrapper
+		expected []byte
+	}{
+		{
+			name: "docker",
+			r: RuntimeWrapper{
+				Runtime: RuntimeDocker{
+					Image: "conduit",
+				},
+			},
+			expected: []byte(`{"image":"conduit","type":"docker"}`),
+		},
+		{
+			name: "http",
+			r: RuntimeWrapper{
+				Runtime: RuntimeHTTP{
+					URL: "http://www.this-is-a-really-good-domain-name-buy-now.com",
+				},
+			},
+			expected: []byte(`{"type":"http","url":"http://www.this-is-a-really-good-domain-name-buy-now.com"}`),
+		},
+	}
+
+	for _, test := range inputs {
+		t.Run(test.name, func(t *testing.T) {
+			output, err := json.Marshal(test.r)
+			require.NoError(t, err)
+			require.Equal(t, test.expected, output)
+		})
+	}
+}

--- a/pkg/cli/initialize_fn.go
+++ b/pkg/cli/initialize_fn.go
@@ -229,14 +229,14 @@ func (f *initModel) Function() (*function.Function, error) {
 
 	// If this is an HTTP function, set the runtime.
 	if f.runtimeType == runtimeHTTP {
-		fn.Steps = append(fn.Steps, function.Step{
+		fn.Steps[fn.Name] = function.Step{
 			Name: fn.Name,
 			Runtime: inngest.RuntimeWrapper{
 				Runtime: inngest.RuntimeHTTP{
 					URL: f.url,
 				},
 			},
-		})
+		}
 	}
 
 	return fn, fn.Validate()

--- a/pkg/cuedefs/v1/function.cue
+++ b/pkg/cuedefs/v1/function.cue
@@ -6,7 +6,7 @@ package v1
 	// triggers represent how the function is invoked.
 	triggers: [...#Trigger]
 	// A function can have > 1 step, which is an individual "action" called in a DAG.
-	steps?: [string]: #Step
+	steps?: [Name=string]: #Step & {name: Name}
 	// idempotency allows the specification of an idempotency key using event data.
 	idempotency?: string
 	// throttle allows you to throttle workflows, only running them a given number

--- a/pkg/scaffold/template.go
+++ b/pkg/scaffold/template.go
@@ -164,7 +164,6 @@ func (t Template) Render(f function.Function) error {
 				return err
 			}
 
-			// TODO: Template contents.
 			return os.WriteFile(filepath.Join(root, path), buf.Bytes(), 0644)
 		})
 		if err != nil {


### PR DESCRIPTION
This lets us ensure that functions are always named, and allows us to
refer to the function name for output data in the future.