### PR TITLE
Send HTTP runtime request with json content type header

### DIFF
--- a/pkg/runtime/http/http.go
+++ b/pkg/runtime/http/http.go
@@ -40,6 +40,7 @@ func (e executor) Execute(ctx context.Context, action inngest.ActionVersion, sta
 	}
 
 	req, err := http.NewRequest(http.MethodPost, rt.URL, bytes.NewBuffer(input))
+	req.Header.Add("Content-Type", "application/json")
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
### Description

When testing this locally, I expected the request body to parsed as JSON in my test endpoint, but the request was missing the `Content-Type: application/json` header. This fixes that.

### Notes

* I did not confirm if the production runtime contained this header or not. 
* Alternatively, we could simplify this using `http.Post(r.url, "application/json" ...)`, but this was the smallest change.