### PR TITLE
Use the workspace environment in published HTTP actions

### DIFF
--- a/pkg/function/function.go
+++ b/pkg/function/function.go
@@ -193,7 +193,12 @@ func (f Function) Actions(ctx context.Context) ([]inngest.ActionVersion, []innge
 }
 
 func (f Function) action(ctx context.Context, s Step, n int) (inngest.ActionVersion, error) {
-	id := fmt.Sprintf("%s-step-%d", f.ID, n)
+	suffix := "test"
+	if state.IsProd() {
+		suffix = "prod"
+	}
+
+	id := fmt.Sprintf("%s-step-%d-%s", f.ID, n, suffix)
 	if prefix, err := state.AccountIdentifier(ctx); err == nil {
 		id = fmt.Sprintf("%s/%s", prefix, id)
 	}

--- a/pkg/runtime/http/http.go
+++ b/pkg/runtime/http/http.go
@@ -40,10 +40,10 @@ func (e executor) Execute(ctx context.Context, action inngest.ActionVersion, sta
 	}
 
 	req, err := http.NewRequest(http.MethodPost, rt.URL, bytes.NewBuffer(input))
-	req.Header.Add("Content-Type", "application/json")
 	if err != nil {
 		return nil, err
 	}
+	req.Header.Add("Content-Type", "application/json")
 
 	resp, err := e.client.Do(req)
 	if err != nil {


### PR DESCRIPTION
This ensures that actions are independent between test and prod;
publishing new test steps doesn't automatically update anything.