### PR TITLE
Use an in-memory queue for our local dev runner

### DIFF
--- a/pkg/cli/run.go
+++ b/pkg/cli/run.go
@@ -52,7 +52,7 @@ type RunUI struct {
 	err error
 
 	// sm is the state manager used for the execution.
-	sm state.Manager
+	sm inmemory.Queue
 	// id is the identifier for the execution, once started.
 	id *state.Identifier
 

--- a/pkg/cuedefs/v1/function.cue
+++ b/pkg/cuedefs/v1/function.cue
@@ -75,7 +75,7 @@ package v1
 	//
 	// If more than one item is supplied in this array, the step will run multiple times after
 	// each preceeding step finishes.
-	after?: [...#After]
+	after: [...#After]
 }
 
 #After: {

--- a/pkg/execution/runner/runner.go
+++ b/pkg/execution/runner/runner.go
@@ -10,42 +10,34 @@ import (
 	"sync"
 	"time"
 
-	"github.com/hashicorp/go-multierror"
 	"github.com/inngest/inngestctl/inngest"
 	"github.com/inngest/inngestctl/pkg/execution/driver"
 	"github.com/inngest/inngestctl/pkg/execution/executor"
 	"github.com/inngest/inngestctl/pkg/execution/state"
+	"github.com/inngest/inngestctl/pkg/execution/state/inmemory"
 	"github.com/oklog/ulid"
-	str2duration "github.com/xhit/go-str2duration/v2"
+	"github.com/xhit/go-str2duration/v2"
 )
 
 // New returns a new runner which executes workflows in-memory.  This is NOT, EVER, IN
 // ANY WAY SHAPE OR FORM SUITABLE FOR PRODUCTION.  Use this locally to test your stuff,
 // please, and only to test.
-func NewInMemoryRunner(sm state.Manager, exec executor.Executor) *InMemoryRunner {
+func NewInMemoryRunner(sm inmemory.Queue, exec executor.Executor) *InMemoryRunner {
 	return &InMemoryRunner{
 		sm:   sm,
 		exec: exec,
-		// execute from the trigger onwards.
-		available: []inngest.Edge{inngest.SourceEdge},
-		queue:     make(chan inngest.Edge),
+		wg:   &sync.WaitGroup{},
 	}
 }
 
 // InMemoryRunner represents a runner that does some funky shit for my peeps please.
 type InMemoryRunner struct {
-	sm   state.Manager
+	sm   inmemory.Queue
 	exec executor.Executor
 
-	queue chan inngest.Edge
-	wg    sync.WaitGroup
-	err   error
-
-	// available reperesents functions that are available to be executed.  We
-	// traverse the step functions from the trigger downards in a BFS, executing
-	// each function in parallel.  Once each function is complete, its children
-	// are pushed to the available slice for execution.
-	available []inngest.Edge
+	// The waitgroup allows us to terminate the inmemory runner when all nodes in
+	// a single function is complete, instead of blocking forever.
+	wg *sync.WaitGroup
 }
 
 // NewRun initializes a new run for the given workflow.
@@ -55,59 +47,69 @@ func (i *InMemoryRunner) NewRun(ctx context.Context, f inngest.Workflow, data ma
 		return nil, fmt.Errorf("error initializing new run: %w", err)
 	}
 	id := state.Identifier()
+
+	i.wg.Add(1)
+	i.sm.Enqueue(inmemory.QueueItem{
+		ID:   id,
+		Edge: inngest.SourceEdge,
+	}, nil)
+
 	return &id, nil
 }
 
 // Execute runs all available tasks, blocking until terminated.
 func (i *InMemoryRunner) Execute(ctx context.Context, id state.Identifier) error {
+	var err error
 	go func() {
-		for next := range i.queue {
-			go i.run(ctx, id, next)
+		for item := range i.sm.Queue() {
+			if err = i.run(ctx, item); err != nil {
+				return
+			}
 		}
 	}()
 
-	// Iterate over all available actions and execute.
-	for len(i.available) > 0 {
-		next := i.available[0]
-		i.available = i.available[1:]
-
-		i.wg.Add(1)
-		i.queue <- next
-	}
-
-	// Wait for all available steps to finish processing.
+	// Wait for all items in the queue to be complete.
 	i.wg.Wait()
-
-	return i.err
+	return err
 }
 
-func (i *InMemoryRunner) run(ctx context.Context, id state.Identifier, e inngest.Edge) {
-	if e.Metadata.Wait != nil {
-		dur, err := str2duration.ParseDuration(*e.Metadata.Wait)
-		if err != nil {
-			i.err = multierror.Append(i.err, fmt.Errorf("invalid edge duration '%s'", *e.Metadata.Wait))
-		}
-		<-time.After(dur)
-	}
+func (i *InMemoryRunner) run(ctx context.Context, item inmemory.QueueItem) error {
+	children, err := i.exec.Execute(ctx, item.ID, item.Edge.Incoming)
 
-	children, err := i.exec.Execute(ctx, id, e.Incoming)
 	if err != nil {
-
+		// TODO: Handle max retries.
 		resp := driver.Response{}
+
 		if !errors.As(err, &resp) || resp.Retryable() {
-			// TODO: Check state to see if we've reached max retry
-			// TODO: Add exponential backoff.
-			i.wg.Add(1)
-			i.queue <- e
+			next := item
+			next.ErrorCount += 1
+			i.sm.Enqueue(next, nil)
 		}
 
-		i.err = multierror.Append(i.err, fmt.Errorf("execution error: %s", err))
+		return fmt.Errorf("execution error: %s", err)
 	}
 
-	for _, item := range children {
+	for _, next := range children {
+		at := time.Now()
+		if next.Metadata.Wait != nil {
+			dur, err := str2duration.ParseDuration(*next.Metadata.Wait)
+			if err != nil {
+				return fmt.Errorf("invalid wait duration: %s", *next.Metadata.Wait)
+			}
+			at = at.Add(dur)
+		}
+
+		// Add to the waitgroup, ensuring that the runner blocks until the enqueued item
+		// is finished.
 		i.wg.Add(1)
-		i.queue <- item
+
+		// Enqueue the next child in our in-memory state queue.
+		i.sm.Enqueue(inmemory.QueueItem{
+			ID:   item.ID,
+			Edge: next,
+		}, &at)
 	}
 
 	i.wg.Done()
+	return nil
 }

--- a/pkg/execution/state/state.go
+++ b/pkg/execution/state/state.go
@@ -75,13 +75,6 @@ type State interface {
 	ActionComplete(id string) bool
 }
 
-/*
-type Response struct {
-	Status int    `json:"status"`
-	Body   string `json:"body"`
-}
-*/
-
 // Loader allows loading of previously stored state based off of a given Identifier.
 type Loader interface {
 	Load(ctx context.Context, i Identifier) (State, error)

--- a/pkg/function/config_test.go
+++ b/pkg/function/config_test.go
@@ -59,6 +59,7 @@ func TestUnmarshal_testdata(t *testing.T) {
 			require.NoError(t, err)
 
 			marshalled, err = json.MarshalIndent(flow, "", "  ")
+			require.NoError(t, err)
 			require.EqualValues(t, strings.TrimSpace(string(td.workflow)), string(marshalled))
 		})
 	}


### PR DESCRIPTION
This PR changes the open-source in-memory runner to use a queue provided
by the in-memory state manager.  This allows us to:

- Properly enqueue items within the state manager, vs storing in a
  buffer
- Store error counts for each step within a dag
- Handle backoffs and retries correctly.

A future PR will enable backoffs as per the function spec.