### PR TITLE
Move engine into devserver package

### DIFF
--- a/pkg/devserver/devserver.go
+++ b/pkg/devserver/devserver.go
@@ -4,7 +4,6 @@ import (
 	"context"
 
 	"github.com/inngest/inngestctl/pkg/api"
-	"github.com/inngest/inngestctl/pkg/engine"
 	"github.com/rs/zerolog"
 )
 
@@ -16,7 +15,7 @@ type Options struct {
 
 type DevServer struct {
 	API    api.API
-	Engine *engine.Engine
+	Engine *Engine
 
 	dir string
 	log *zerolog.Logger
@@ -24,9 +23,7 @@ type DevServer struct {
 
 // Create and start a new dev server (API, Exectutor, State, Logger, etc.)
 func NewDevServer(o Options) (DevServer, error) {
-	eng, err := engine.New(engine.Options{
-		Logger: o.Log,
-	})
+	eng, err := NewEngine(o.Log)
 	if err != nil {
 		return DevServer{}, err
 	}

--- a/pkg/devserver/engine.go
+++ b/pkg/devserver/engine.go
@@ -1,4 +1,4 @@
-package engine
+package devserver
 
 import (
 	"context"
@@ -21,10 +21,6 @@ import (
 	cron "github.com/robfig/cron/v3"
 	"github.com/rs/zerolog"
 )
-
-type Options struct {
-	Logger *zerolog.Logger
-}
 
 // Engine bundles together a runner, in-memory state manager, and local functions
 // for use within a local dev server, for development only.
@@ -57,14 +53,14 @@ type Engine struct {
 	sm inmemory.Queue
 }
 
-func New(o Options) (*Engine, error) {
-	logger := o.Logger.With().Str("caller", "engine").Logger()
+func NewEngine(l *zerolog.Logger) (*Engine, error) {
+	logger := l.With().Str("caller", "engine").Logger()
 
 	eng := &Engine{
 		log:           &logger,
 		EventTriggers: map[string][]function.Function{},
 		al:            actionloader.NewMemoryLoader(),
-		sm:            NewLoggingQueue(o.Logger),
+		sm:            NewLoggingQueue(l),
 	}
 
 	// Create our drivers.

--- a/pkg/devserver/engine_test.go
+++ b/pkg/devserver/engine_test.go
@@ -1,4 +1,4 @@
-package engine
+package devserver
 
 import (
 	"bytes"
@@ -22,9 +22,7 @@ func TestEngine_async(t *testing.T) {
 	ctx := context.Background()
 	buf := &bytes.Buffer{}
 
-	e, err := New(Options{
-		Logger: logger.Buffered(buf),
-	})
+	e, err := NewEngine(logger.Buffered(buf))
 	require.NoError(t, err)
 
 	err = e.SetFunctions(ctx, []*function.Function{

--- a/pkg/devserver/logging_executor.go
+++ b/pkg/devserver/logging_executor.go
@@ -1,4 +1,4 @@
-package engine
+package devserver
 
 import (
 	"context"

--- a/pkg/devserver/logging_queue.go
+++ b/pkg/devserver/logging_queue.go
@@ -1,4 +1,4 @@
-package engine
+package devserver
 
 import (
 	"context"


### PR DESCRIPTION
The engine is tied directly to the development server;  it is not
capable of being used outside of a development environment.  To this
effect, we move the engnine into the devserver package.

Note that this is still an exported member (for the time being).