### PR TITLE
Dev server JSON output

### DIFF
--- a/cmd/commands/dev.go
+++ b/cmd/commands/dev.go
@@ -9,11 +9,6 @@ import (
 	"github.com/spf13/cobra"
 )
 
-var (
-	prettyOutput bool
-	jsonOutput   bool
-)
-
 func NewCmdDev() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:     "dev",
@@ -24,8 +19,6 @@ func NewCmdDev() *cobra.Command {
 
 	cmd.Flags().StringP("port", "p", "9999", "port to run the API on")
 	cmd.Flags().String("dir", ".", "directory to load functions from")
-	cmd.Flags().BoolVar(&prettyOutput, "pretty", false, "pretty print the JSON output")
-	cmd.Flags().BoolVar(&jsonOutput, "json", false, "pretty print the JSON output")
 	return cmd
 }
 

--- a/cmd/commands/root.go
+++ b/cmd/commands/root.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"os"
 
+	isatty "github.com/mattn/go-isatty"
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
 )
@@ -27,9 +28,15 @@ func Execute() {
 	}
 
 	rootCmd.PersistentFlags().Bool("prod", false, "Use the production environment for the current command.")
+	rootCmd.PersistentFlags().Bool("json", false, "Output logs as JSON.  Set to true if stdout is not a TTY.")
 
 	if err := viper.BindPFlags(rootCmd.PersistentFlags()); err != nil {
 		panic(err)
+	}
+
+	if !isatty.IsTerminal(os.Stdout.Fd()) {
+		// Alwyas use JSON when not in a terminal
+		viper.Set("json", true)
 	}
 
 	// Register Top Level Commands

--- a/pkg/devserver/engine.go
+++ b/pkg/devserver/engine.go
@@ -6,7 +6,6 @@ import (
 	"os"
 	"time"
 
-	tea "github.com/charmbracelet/bubbletea"
 	"github.com/hashicorp/go-multierror"
 	"github.com/inngest/inngestctl/inngest"
 	"github.com/inngest/inngestctl/pkg/cli"
@@ -181,9 +180,6 @@ func (eng Engine) buildImages(ctx context.Context) error {
 		return nil
 	}
 
-	// XXX: Depending on the type of output here, we want to either
-	// create an interactive UI for building images or show JSON output
-	// as we build.
 	ui, err := cli.NewBuilder(ctx, cli.BuilderUIOpts{
 		QuitOnComplete: true,
 		BuildOpts:      opts,
@@ -192,7 +188,10 @@ func (eng Engine) buildImages(ctx context.Context) error {
 		fmt.Println("\n" + cli.RenderError(err.Error()) + "\n")
 		os.Exit(1)
 	}
-	if err := tea.NewProgram(ui).Start(); err != nil {
+	// calling Start on our UI instance invokes either a pretty TTY output
+	// via tea, or renders output as JSON directly depending on the global
+	// JSON flag.
+	if err := ui.Start(ctx); err != nil {
 		fmt.Println("\n" + cli.RenderError(err.Error()) + "\n")
 		os.Exit(1)
 	}

--- a/pkg/logger/zerolog.go
+++ b/pkg/logger/zerolog.go
@@ -6,6 +6,7 @@ import (
 	"os"
 
 	"github.com/rs/zerolog"
+	"github.com/spf13/viper"
 )
 
 const (
@@ -41,11 +42,12 @@ func From(ctx context.Context) *zerolog.Logger {
 func New(lvl zerolog.Level) *zerolog.Logger {
 	l := zerolog.New(os.Stderr).Level(lvl).With().Timestamp().Logger()
 
-	// TODO: Switch between log formats
-	l = l.Output(zerolog.ConsoleWriter{
-		Out:         os.Stderr,
-		FormatLevel: func(i interface{}) string { return "" },
-	})
+	if !viper.GetBool("json") {
+		l = l.Output(zerolog.ConsoleWriter{
+			Out:         os.Stderr,
+			FormatLevel: func(i interface{}) string { return "" },
+		})
+	}
 
 	return &l
 }
@@ -63,10 +65,14 @@ func Default() *zerolog.Logger {
 }
 
 func Buffered(buf io.Writer) *zerolog.Logger {
-	l := Default()
-	l.Output(zerolog.ConsoleWriter{
-		Out:         buf,
-		FormatLevel: func(i interface{}) string { return "" },
-	})
-	return l
+	l := zerolog.New(buf).Level(DefaultLevel).With().Timestamp().Logger()
+
+	if !viper.GetBool("json") {
+		l = l.Output(zerolog.ConsoleWriter{
+			Out:         buf,
+			FormatLevel: func(i interface{}) string { return "" },
+		})
+	}
+
+	return &l
 }


### PR DESCRIPTION
This PR introduces a `--json` flag and TTY checking.  The dev server will automatically use JSON output when we're not a TTY (eg. in CI/CD).

We also add support for JSON within the Build UI, showing JSON output when building images vs a progress UI.