### PR TITLE
Print response error for login command

### DIFF
--- a/inngest/client/client.go
+++ b/inngest/client/client.go
@@ -127,8 +127,8 @@ func (c httpClient) Login(ctx context.Context, email, password string) ([]byte, 
 	}
 
 	type response struct {
-		Error string
-		JWT   string
+		Message string
+		JWT     string
 	}
 
 	r := &response{}
@@ -137,7 +137,7 @@ func (c httpClient) Login(ctx context.Context, email, password string) ([]byte, 
 	}
 
 	if resp.StatusCode != 200 {
-		return nil, fmt.Errorf("%s", r.Error)
+		return nil, fmt.Errorf("%s", r.Message)
 	}
 
 	return []byte(r.JWT), nil


### PR DESCRIPTION
### Purpose
The response format in this API endpoints was previously modified. This returns the user friendly error to the terminal output.

### Notes
Before change:
```
inngest login
Your email: dan+demo@inngest.com
Enter your password:
Logging in...
 Error  unable to log in:
 ```
 After change:
 ```
inngest login
Your email: dan+demo@inngest.com
Enter your password:
Logging in...
 Error  unable to log in: You do not have a password set, please login and create a password: https://app.inngest.com/login?ref=cli
 ```