### PR TITLE
Add event payload to dev server log output

### DIFF
--- a/pkg/api/api.go
+++ b/pkg/api/api.go
@@ -108,7 +108,9 @@ func (a API) ReceiveEvent(w http.ResponseWriter, r *http.Request) {
 	for _, evt := range events {
 		copied := evt
 		go func(e event.Event) {
-			a.log.Info().Str("event", e.Name).Msg("received event")
+			a.log.Info().Str("event", e.Name).
+				Interface("payload", e).
+				Msg("received event")
 			if err := a.handler(r.Context(), &e); err != nil {
 				a.log.Error().Msg(err.Error())
 			}


### PR DESCRIPTION
## Description

To enable the developer to quickly verify a given payload

### Notes

Before
```
10:06PM api > received event event=worker.dispatched
```

After
```
10:06PM api > received event event=worker.dispatched payload={"data":{"message":"Are you available today at 9am? (y/n)"},"name":"worker.dispatched","user":{"external_id":"1234","name":"Johnny Utah","phone":"+1 (213) 555-1234"}}
```