### PR TITLE
Change executor interface to make AvailableChildren public

### DIFF
--- a/pkg/devserver/engine.go
+++ b/pkg/devserver/engine.go
@@ -69,7 +69,7 @@ func NewEngine(l *zerolog.Logger) (*Engine, error) {
 	}
 
 	// Create an executor with the state manager and drivers.
-	eng.exec, err = executor.NewExecutor(
+	exec, err := executor.NewExecutor(
 		executor.WithStateManager(eng.sm),
 		executor.WithActionLoader(eng.al),
 		executor.WithRuntimeDrivers(
@@ -80,6 +80,7 @@ func NewEngine(l *zerolog.Logger) (*Engine, error) {
 		return nil, fmt.Errorf("error creating executor: %w", err)
 	}
 
+	eng.exec = NewLoggingExecutor(exec, l)
 	eng.runner = runner.NewInMemoryRunner(eng.sm, eng.exec)
 
 	return eng, nil

--- a/pkg/execution/driver/driver.go
+++ b/pkg/execution/driver/driver.go
@@ -20,14 +20,14 @@ type Response struct {
 	// Managing messaging and monitoring of asynchronous jobs is outside of
 	// the scope of this executor.  It's possible to store your own queues
 	// and state for managing asynchronous jobs in another manager.
-	Scheduled bool
+	Scheduled bool `json:"scheduled"`
 
 	// Output is the output from an action, as a JSON map.
-	Output map[string]interface{}
+	Output map[string]interface{} `json:"output"`
 
 	// Err represents the error from the action, if the action errored.
 	// If the action terminated successfully this must be nil.
-	Err error
+	Err error `json:"err"`
 }
 
 // Retryable returns whether the response indicates that the action is

--- a/pkg/execution/executor/executor.go
+++ b/pkg/execution/executor/executor.go
@@ -57,7 +57,7 @@ type Executor interface {
 	// It is important for this function to be atomic;  if the function was scheduled
 	// and the context terminates, we must store the output or async data in workflow
 	// state then schedule the child functions else the workflow will terminate early.
-	Execute(ctx context.Context, id state.Identifier, from string) ([]inngest.Edge, error)
+	Execute(ctx context.Context, id state.Identifier, from string) (*driver.Response, []inngest.Edge, error)
 
 	// AvailableChildren returns the available children to execute from a given action, based off of
 	// state fetched from the executor.
@@ -146,28 +146,28 @@ type executor struct {
 // Execute loads a workflow and the current run state, then executes the
 // workflow via an executor.  This returns all available steps we can run from
 // the workflow after the step has been executed.
-func (e *executor) Execute(ctx context.Context, id state.Identifier, from string) ([]inngest.Edge, error) {
+func (e *executor) Execute(ctx context.Context, id state.Identifier, from string) (*driver.Response, []inngest.Edge, error) {
 	state, err := e.sm.Load(ctx, id)
 	if err != nil {
-		return nil, err
+		return nil, nil, err
 	}
 
 	w, err := state.Workflow()
 	if err != nil {
-		return nil, err
+		return nil, nil, err
 	}
 
-	next, err := e.run(ctx, w, id, from, state)
+	resp, next, err := e.run(ctx, w, id, from, state)
 	if err != nil {
 		// This is likely a driver.Response, which itself includes
 		// whether the action can be retried based off of the output.
 		//
 		// The runner is responsible for scheduling jobs and will check
 		// whether the action can be retried.
-		return nil, err
+		return resp, nil, err
 	}
 
-	return next, nil
+	return resp, next, nil
 }
 
 func (e *executor) ExpressionData(ctx context.Context, id state.Identifier) (map[string]interface{}, error) {
@@ -179,7 +179,12 @@ func (e *executor) ExpressionData(ctx context.Context, id state.Identifier) (map
 }
 
 // run executes the action with the given client ID.
-func (e *executor) run(ctx context.Context, w inngest.Workflow, id state.Identifier, clientID string, s state.State) ([]inngest.Edge, error) {
+func (e *executor) run(ctx context.Context, w inngest.Workflow, id state.Identifier, clientID string, s state.State) (*driver.Response, []inngest.Edge, error) {
+	var (
+		response *driver.Response
+		err      error
+	)
+
 	if clientID != inngest.TriggerName {
 		var step *inngest.Step
 		for _, s := range w.Steps {
@@ -189,26 +194,29 @@ func (e *executor) run(ctx context.Context, w inngest.Workflow, id state.Identif
 			}
 		}
 		if step == nil {
-			return nil, fmt.Errorf("unknown vertex: %s", clientID)
+			return nil, nil, fmt.Errorf("unknown vertex: %s", clientID)
 		}
-		response, err := e.executeAction(ctx, id, step)
+		response, err = e.executeAction(ctx, id, step)
 		if err != nil {
-			return nil, err
+			return nil, nil, err
 		}
 		if response.Err != nil {
 			// This action errored.  We've stored this in our state manager already;
-			// return the response error only.
-			return nil, response
+			// return the response error only.  We can use the same variable for both
+			// the response and the error to indicate an error value.
+			return response, nil, response
 		}
 		if response.Scheduled {
 			// This action is not yet complete, so we can't traverse
 			// its children.  We assume that the driver is responsible for
 			// retrying and coordinating async state here;  the executor's
 			// job is to execute the action only.
-			return nil, nil
+			return response, nil, nil
 		}
 	}
-	return e.AvailableChildren(ctx, id, clientID)
+
+	edges, err := e.AvailableChildren(ctx, id, clientID)
+	return response, edges, err
 }
 
 func (e *executor) executeAction(ctx context.Context, id state.Identifier, action *inngest.Step) (*driver.Response, error) {

--- a/pkg/execution/executor/executor_test.go
+++ b/pkg/execution/executor/executor_test.go
@@ -282,6 +282,14 @@ func TestExecute_edge_expressions(t *testing.T) {
 	require.Equal(t, len(driver.Executed), 0)
 	require.Equal(t, len(available), 1)
 	require.ElementsMatch(t, []string{"run-step-trigger"}, availableIDs(available))
+	edges, err := exec.AvailableChildren(ctx, state.Identifier(), inngest.TriggerName)
+	require.NoError(t, err)
+	require.ElementsMatch(t, []string{"run-step-trigger"}, availableIDs(edges))
+
+	// As we haven't ran the step called run-step-trigger, we should have no children available.
+	edges, err = exec.AvailableChildren(ctx, state.Identifier(), "run-step-trigger")
+	require.NoError(t, err)
+	require.ElementsMatch(t, []string{}, availableIDs(edges))
 
 	// Run the next step.
 	available, err = exec.Execute(ctx, state.Identifier(), "run-step-trigger")
@@ -289,6 +297,9 @@ func TestExecute_edge_expressions(t *testing.T) {
 	assert.Equal(t, 1, len(driver.Executed))
 	assert.Equal(t, 1, len(available))
 	assert.ElementsMatch(t, []string{"run-step-child"}, availableIDs(available))
+	edges, err = exec.AvailableChildren(ctx, state.Identifier(), "run-step-trigger")
+	require.NoError(t, err)
+	require.ElementsMatch(t, []string{"run-step-child"}, availableIDs(edges))
 }
 
 func availableIDs(edges []inngest.Edge) []string {

--- a/pkg/execution/executor/executor_test.go
+++ b/pkg/execution/executor/executor_test.go
@@ -134,7 +134,7 @@ func TestExecute_state(t *testing.T) {
 
 	// Executing the trigger does nothing but validate which descendents from the trigger
 	// in the dag can run.
-	available, err := exec.Execute(ctx, state.Identifier(), inngest.TriggerName)
+	_, available, err := exec.Execute(ctx, state.Identifier(), inngest.TriggerName)
 	assert.NoError(t, err)
 	assert.Equal(t, len(driver.Executed), 0)
 	assert.Equal(t, len(available), 2)
@@ -145,7 +145,7 @@ func TestExecute_state(t *testing.T) {
 	assert.Equal(t, 0, len(state.Actions()))
 
 	// Run the first item.
-	available, err = exec.Execute(ctx, state.Identifier(), "1")
+	_, available, err = exec.Execute(ctx, state.Identifier(), "1")
 	assert.NoError(t, err)
 	assert.Equal(t, 1, len(driver.Executed))
 	assert.Equal(t, 1, len(available))
@@ -159,7 +159,7 @@ func TestExecute_state(t *testing.T) {
 	// Test "scheduled" responses.  The driver should respond with a Scheduled
 	// message, which means that the function has begun execution but no further
 	// actions are available.
-	available, err = exec.Execute(ctx, state.Identifier(), "4")
+	_, available, err = exec.Execute(ctx, state.Identifier(), "4")
 	assert.NoError(t, err)
 	assert.Equal(t, 2, len(driver.Executed), "function not executed")
 	assert.Equal(t, 0, len(available), "incorrect number of functions available")
@@ -170,7 +170,7 @@ func TestExecute_state(t *testing.T) {
 	assert.Equal(t, 0, len(state.Errors()))
 
 	// Test "error" responses
-	available, err = exec.Execute(ctx, state.Identifier(), "5")
+	_, available, err = exec.Execute(ctx, state.Identifier(), "5")
 	assert.Error(t, err)
 	assert.Equal(t, 3, len(driver.Executed), "function not executed")
 	assert.Equal(t, 0, len(available), "incorrect number of functions available")
@@ -277,7 +277,7 @@ func TestExecute_edge_expressions(t *testing.T) {
 	)
 	require.NoError(t, err)
 
-	available, err := exec.Execute(ctx, state.Identifier(), inngest.TriggerName)
+	_, available, err := exec.Execute(ctx, state.Identifier(), inngest.TriggerName)
 	require.NoError(t, err)
 	require.Equal(t, len(driver.Executed), 0)
 	require.Equal(t, len(available), 1)
@@ -292,7 +292,7 @@ func TestExecute_edge_expressions(t *testing.T) {
 	require.ElementsMatch(t, []string{}, availableIDs(edges))
 
 	// Run the next step.
-	available, err = exec.Execute(ctx, state.Identifier(), "run-step-trigger")
+	_, available, err = exec.Execute(ctx, state.Identifier(), "run-step-trigger")
 	assert.NoError(t, err)
 	assert.Equal(t, 1, len(driver.Executed))
 	assert.Equal(t, 1, len(available))


### PR DESCRIPTION
This allows coordinators (eg. runners) to query for the children that
are available to execute, from an instantiated executor, at any point.

It also exposes the executor's driver.Response result after running
a step.