### PR TITLE
Add step IDs, alongside uint-based clientID fields

### DIFF
--- a/inngest/action.go
+++ b/inngest/action.go
@@ -10,6 +10,7 @@ import (
 type ActionVersion struct {
 	// DSN represents the immutable identifier for the action.
 	DSN string `json:"dsn"`
+
 	// Name represents the name of this action
 	Name string `json:"name"`
 

--- a/inngest/graph.go
+++ b/inngest/graph.go
@@ -28,7 +28,7 @@ func NewGraph(w Workflow) (Graph, error) {
 	for _, s := range w.Steps {
 		step := s
 		v := Vertex{Step: &step}
-		vertices[step.ClientID] = v
+		vertices[step.ID] = v
 		g.Add(v)
 	}
 
@@ -55,8 +55,8 @@ func (g Graph) Workflow() Workflow {
 	return g.workflow
 }
 
-func (g Graph) From(clientID string) []GraphEdge {
-	ifaces := g.EdgesFrom(LookupVertex{ClientID: clientID})
+func (g Graph) From(id string) []GraphEdge {
+	ifaces := g.EdgesFrom(LookupVertex{ID: id})
 	edges := make([]GraphEdge, len(ifaces))
 	for n, i := range ifaces {
 		edges[n] = i.(GraphEdge)
@@ -65,11 +65,11 @@ func (g Graph) From(clientID string) []GraphEdge {
 }
 
 type LookupVertex struct {
-	ClientID string
+	ID string
 }
 
 func (l LookupVertex) Hashcode() interface{} {
-	return l.ClientID
+	return l.ID
 }
 
 // Vertex represents an action or the trigger within our workflow graph
@@ -86,7 +86,7 @@ func (g Vertex) ID() string {
 	if g.Step == nil {
 		return TriggerName
 	}
-	return g.Step.ClientID
+	return g.Step.ID
 }
 
 // Edge inherits functionality from simple.Edge and includes our workflow edge

--- a/inngest/graph_test.go
+++ b/inngest/graph_test.go
@@ -10,16 +10,16 @@ func TestGraph_create(t *testing.T) {
 	w := Workflow{
 		Steps: []Step{
 			{
-				ClientID: "first",
-				Name:     "My first step!",
+				ID:   "first",
+				Name: "My first step!",
 			},
 			{
-				ClientID: "#2",
-				Name:     "Second",
+				ID:   "#2",
+				Name: "Second",
 			},
 			{
-				ClientID: "parallel #2",
-				Name:     "Parallel #2",
+				ID:   "parallel #2",
+				Name: "Parallel #2",
 			},
 		},
 		Edges: []Edge{
@@ -46,16 +46,16 @@ func TestGraph_lookup(t *testing.T) {
 	w := Workflow{
 		Steps: []Step{
 			{
-				ClientID: "first",
-				Name:     "My first step!",
+				ID:   "first",
+				Name: "My first step!",
 			},
 			{
-				ClientID: "#2",
-				Name:     "Second",
+				ID:   "#2",
+				Name: "Second",
 			},
 			{
-				ClientID: "parallel #2",
-				Name:     "Parallel #2",
+				ID:   "parallel #2",
+				Name: "Parallel #2",
 			},
 		},
 		Edges: []Edge{
@@ -80,19 +80,19 @@ func TestGraph_lookup(t *testing.T) {
 	// Nodes from trigger
 	edges := g.EdgesFrom(LookupVertex{TriggerName})
 	require.Equal(t, 1, len(edges))
-	require.Equal(t, "first", edges[0].Target().(Vertex).Step.ClientID)
+	require.Equal(t, "first", edges[0].Target().(Vertex).Step.ID)
 
 	// a helper func.
 	from := g.From(TriggerName)
 	require.Equal(t, 1, len(from))
-	require.Equal(t, "first", from[0].Incoming.Step.ClientID)
+	require.Equal(t, "first", from[0].Incoming.Step.ID)
 
 	// Nodes from first vertex.
 	edges = g.EdgesFrom(LookupVertex{"first"})
 	require.Equal(t, 2, len(edges))
 	ids := []string{
-		edges[0].Target().(Vertex).Step.ClientID,
-		edges[1].Target().(Vertex).Step.ClientID,
+		edges[0].Target().(Vertex).Step.ID,
+		edges[1].Target().(Vertex).Step.ID,
 	}
 	require.ElementsMatch(t, []string{"#2", "parallel #2"}, ids)
 }

--- a/inngest/workflow.go
+++ b/inngest/workflow.go
@@ -64,7 +64,13 @@ type CronTrigger struct {
 
 // Step is a reference to an action within a workflow.
 type Step struct {
-	ClientID string                 `json:"clientID"`
+	// ID is a string-based identifier for the step, used to reference
+	// the step's output in code.
+	ID string `json:"id"`
+	// ClientID represnets an incrementing ID for the step.
+	//
+	// Deprecated:  use a string-based ID instead.
+	ClientID uint                   `json:"clientID"`
 	Name     string                 `json:"name"`
 	DSN      string                 `json:"dsn"`
 	Version  *VersionConstraint     `json:"version,omitempty"`

--- a/internal/cuedefs/pkg/workflows/workflows.cue
+++ b/internal/cuedefs/pkg/workflows/workflows.cue
@@ -46,8 +46,8 @@ import (
 #Action: {
 	// clientID represents the ID of the action as represented by edges and
 	// by the frontend's rendering.
-	clientID: uint
-	clientID: >=1
+	clientID: uint & >=1
+	id:       string | *""
 	// name of the action
 	name: string
 	// dsn of the action.  eg "com.datosapp.logic.if" to test a predicate

--- a/pkg/cuedefs/v1/function.cue
+++ b/pkg/cuedefs/v1/function.cue
@@ -8,7 +8,7 @@ package v1
 	triggers: [...#Trigger]
 
 	// A function can have > 1 step, which is an individual "action" called in a DAG.
-	steps?: [Name=string]: #Step & {name: Name}
+	steps?: [ID=string]: #Step & {id: ID}
 
 	// idempotency allows the specification of an idempotency key using event data.
 	// If specified, this overrides the throttle object.
@@ -64,6 +64,7 @@ package v1
 // Step represents a single action within a function.  An action is an individual unit
 // of code which is scheduled as part of the function execution.
 #Step: {
+	id:   string
 	name: string | *""
 
 	// path represents the location on disk for the step defintiion.  A single function

--- a/pkg/devserver/engine.go
+++ b/pkg/devserver/engine.go
@@ -111,6 +111,12 @@ func (eng *Engine) Load(ctx context.Context, dir string) error {
 }
 
 func (eng *Engine) SetFunctions(ctx context.Context, functions []*function.Function) error {
+	for _, f := range functions {
+		if err := f.Validate(ctx); err != nil {
+			return fmt.Errorf("error setting functions: %w", err)
+		}
+	}
+
 	eng.Functions = functions
 
 	// Build all function images.

--- a/pkg/devserver/engine_test.go
+++ b/pkg/devserver/engine_test.go
@@ -38,7 +38,8 @@ func TestEngine_async(t *testing.T) {
 			},
 			Steps: map[string]function.Step{
 				"first": {
-					Name: "first",
+					ID:   "first",
+					Name: "Basic step",
 					Runtime: inngest.RuntimeWrapper{
 						Runtime: &mockdriver.Mock{},
 					},
@@ -49,7 +50,8 @@ func TestEngine_async(t *testing.T) {
 					},
 				},
 				"wait-for-evt": {
-					Name: "wait-for-evt",
+					ID:   "wait-for-evt",
+					Name: "A step with a wait",
 					Runtime: inngest.RuntimeWrapper{
 						Runtime: &mockdriver.Mock{},
 					},
@@ -114,7 +116,7 @@ func TestEngine_async(t *testing.T) {
 		return len(driver.Executed) == 1
 	}, 50*time.Millisecond, 10*time.Millisecond)
 	// Assert that the first step ran.
-	require.Equal(t, "first", driver.Executed["first"].Name)
+	require.Equal(t, "Basic step", driver.Executed["first"].Name)
 	// And we should have a pause.
 	require.Eventually(t, func() bool {
 		return len(e.sm.Pauses()) == 1
@@ -147,7 +149,7 @@ func TestEngine_async(t *testing.T) {
 	require.Eventually(t, func() bool {
 		return len(driver.Executed) == 2
 	}, 50*time.Millisecond, 10*time.Millisecond)
-	require.Equal(t, "wait-for-evt", driver.Executed["wait-for-evt"].Name)
+	require.Equal(t, "A step with a wait", driver.Executed["wait-for-evt"].Name)
 }
 
 func strptr(s string) *string {

--- a/pkg/execution/driver/mockdriver/mockdriver.go
+++ b/pkg/execution/driver/mockdriver/mockdriver.go
@@ -37,9 +37,9 @@ func (m *Mock) Execute(ctx context.Context, state state.State, action inngest.Ac
 		m.Executed = map[string]inngest.ActionVersion{}
 	}
 
-	m.Executed[step.ClientID] = action
+	m.Executed[step.ID] = action
 
-	response := m.Responses[step.ClientID]
-	err := m.Errors[step.ClientID]
+	response := m.Responses[step.ID]
+	err := m.Errors[step.ID]
 	return &response, err
 }

--- a/pkg/execution/executor/executor_test.go
+++ b/pkg/execution/executor/executor_test.go
@@ -50,32 +50,32 @@ func TestExecute_state(t *testing.T) {
 		UUID: uuid.New(),
 		Steps: []inngest.Step{
 			{
-				DSN:      "test",
-				ClientID: "1",
+				DSN: "test",
+				ID:  "1",
 			},
 			{
-				DSN:      "test",
-				ClientID: "2",
+				DSN: "test",
+				ID:  "2",
 			},
 			{
-				DSN:      "test",
-				ClientID: "3",
+				DSN: "test",
+				ID:  "3",
 			},
 			{
-				DSN:      "test",
-				ClientID: "4",
+				DSN: "test",
+				ID:  "4",
 			},
 			{
-				DSN:      "test",
-				ClientID: "5",
+				DSN: "test",
+				ID:  "5",
 			},
 			{
-				DSN:      "test",
-				ClientID: "6",
+				DSN: "test",
+				ID:  "6",
 			},
 			{
-				DSN:      "test",
-				ClientID: "7",
+				DSN: "test",
+				ID:  "7",
 			},
 		},
 		Edges: []inngest.Edge{
@@ -199,20 +199,20 @@ func TestExecute_edge_expressions(t *testing.T) {
 		UUID: uuid.New(),
 		Steps: []inngest.Step{
 			{
-				DSN:      "test",
-				ClientID: "run-step-trigger",
+				DSN: "test",
+				ID:  "run-step-trigger",
 			},
 			{
-				DSN:      "test",
-				ClientID: "dont-run-step-trigger",
+				DSN: "test",
+				ID:  "dont-run-step-trigger",
 			},
 			{
-				DSN:      "test",
-				ClientID: "run-step-child",
+				DSN: "test",
+				ID:  "run-step-child",
 			},
 			{
-				DSN:      "test",
-				ClientID: "dont-run-step-child",
+				DSN: "test",
+				ID:  "dont-run-step-child",
 			},
 		},
 		Edges: []inngest.Edge{

--- a/pkg/execution/runner/runner_test.go
+++ b/pkg/execution/runner/runner_test.go
@@ -113,8 +113,8 @@ func TestRunner_run_source(t *testing.T) {
 	f := inngest.Workflow{
 		Steps: []inngest.Step{
 			{
-				ClientID: "first",
-				DSN:      "step-a",
+				ID:  "first",
+				DSN: "step-a",
 			},
 		},
 		Edges: []inngest.Edge{
@@ -171,8 +171,8 @@ func TestRunner_run_retry(t *testing.T) {
 	f := inngest.Workflow{
 		Steps: []inngest.Step{
 			{
-				ClientID: "first",
-				DSN:      "step-a",
+				ID:  "first",
+				DSN: "step-a",
 			},
 		},
 		Edges: []inngest.Edge{

--- a/pkg/function/config_test.go
+++ b/pkg/function/config_test.go
@@ -85,7 +85,8 @@ func TestUnmarshal(t *testing.T) {
 					{EventTrigger: &EventTrigger{Event: "test.event"}},
 				},
 				Steps: map[string]Step{
-					"test": {
+					defaultStepName: {
+						ID:   defaultStepName,
 						Name: "test",
 						Runtime: inngest.RuntimeWrapper{
 							Runtime: inngest.RuntimeDocker{},
@@ -117,7 +118,8 @@ func TestUnmarshal(t *testing.T) {
 					{EventTrigger: &EventTrigger{Event: "test.event"}},
 				},
 				Steps: map[string]Step{
-					"test": {
+					defaultStepName: {
+						ID:   defaultStepName,
 						Name: "test",
 						Runtime: inngest.RuntimeWrapper{
 							Runtime: inngest.RuntimeDocker{},
@@ -154,7 +156,8 @@ func TestUnmarshal(t *testing.T) {
 					{EventTrigger: &EventTrigger{Event: "test.event"}},
 				},
 				Steps: map[string]Step{
-					"test": {
+					defaultStepName: {
+						ID:   defaultStepName,
 						Name: "test",
 						Runtime: inngest.RuntimeWrapper{
 							Runtime: inngest.RuntimeDocker{},

--- a/pkg/function/function_test.go
+++ b/pkg/function/function_test.go
@@ -42,7 +42,7 @@ func TestDerivedConfigDefault(t *testing.T) {
 
 	expectedActionVersion := inngest.ActionVersion{
 		Name:   "Foo",
-		DSN:    "magical-id-step-foo-test",
+		DSN:    "magical-id-step-step-function-test",
 		Scopes: []string{"secret:read:*"},
 		Runtime: inngest.RuntimeWrapper{
 			Runtime: inngest.RuntimeDocker{},
@@ -57,7 +57,7 @@ import (
 
 action: actions.#Action
 action: {
-  dsn:  "magical-id-step-foo-test"
+  dsn:  "magical-id-step-step-function-test"
   name: "Foo"
   scopes: ["secret:read:*"]
   runtime: type: "docker"
@@ -86,7 +86,8 @@ action: {
 		},
 		Steps: []inngest.Step{
 			{
-				ClientID: "Foo",
+				ID:       defaultStepName,
+				ClientID: 1,
 				Name:     expectedActionVersion.Name,
 				DSN:      expectedActionVersion.DSN,
 			},
@@ -94,7 +95,7 @@ action: {
 		Edges: []inngest.Edge{
 			{
 				Outgoing: inngest.TriggerName,
-				Incoming: "Foo",
+				Incoming: defaultStepName,
 			},
 		},
 	}
@@ -113,13 +114,14 @@ workflow: workflows.#Workflow & {
     expression: "event.version >= 2"
   }]
   actions: [{
-    clientID: "Foo"
+    id:       "step-function"
+    clientID: 1
     name:     "Foo"
-    dsn:      "magical-id-step-foo-test"
+    dsn:      "magical-id-step-step-function-test"
   }]
   edges: [{
     outgoing: "$trigger"
-    incoming: "Foo"
+    incoming: "step-function"
     metadata: {}
   }]
 }`
@@ -168,6 +170,7 @@ func TestEventDefinitionAbsolutePath(t *testing.T) {
 
 func TestFunctionActions_single(t *testing.T) {
 	fn := Function{
+		ID:   "hi",
 		Name: "test",
 		Triggers: []Trigger{{
 			EventTrigger: &EventTrigger{
@@ -176,6 +179,7 @@ func TestFunctionActions_single(t *testing.T) {
 		}},
 		Steps: map[string]Step{
 			"single": {
+				ID:   "single",
 				Name: "single",
 				Runtime: inngest.RuntimeWrapper{
 					Runtime: &mockdriver.Mock{},
@@ -183,6 +187,8 @@ func TestFunctionActions_single(t *testing.T) {
 			},
 		},
 	}
+	err := fn.Validate(context.Background())
+	require.NoError(t, err)
 
 	actions, edges, err := fn.Actions(context.Background())
 	require.NoError(t, err)

--- a/pkg/function/testdata/complex.txtar
+++ b/pkg/function/testdata/complex.txtar
@@ -15,6 +15,7 @@ function: defs.#Function & {
 	idempotency: "{{ event.data.foo }}"
 	steps: {
 		first: {
+			name: "My first func"
 			runtime: defs.#RuntimeDocker
 			after: [{
 				step: "$trigger"
@@ -22,6 +23,7 @@ function: defs.#Function & {
 			}]
 		}
 		second: {
+			name: "A second func that does something cool!"
 			runtime: defs.#RuntimeDocker
 			after: [{
 				step: "first"
@@ -47,8 +49,9 @@ function: defs.#Function & {
   },
   "steps": {
     "first": {
+      "id": "first",
       "path": "",
-      "name": "first",
+      "name": "My first func",
       "runtime": {
         "type": "docker"
       },
@@ -60,8 +63,9 @@ function: defs.#Function & {
       ]
     },
     "second": {
+      "id": "second",
       "path": "",
-      "name": "second",
+      "name": "A second func that does something cool!",
       "runtime": {
         "type": "docker"
       },
@@ -90,13 +94,15 @@ function: defs.#Function & {
   ],
   "actions": [
     {
-      "clientID": "first",
-      "name": "first",
+      "id": "first",
+      "clientID": 1,
+      "name": "My first func",
       "dsn": "some-id-step-first-test"
     },
     {
-      "clientID": "second",
-      "name": "second",
+      "id": "second",
+      "clientID": 2,
+      "name": "A second func that does something cool!",
       "dsn": "some-id-step-second-test"
     }
   ],


### PR DESCRIPTION
This adds backcompat to our uint-based clientIDs, adding a new `id`
field to steps which will replace the client IDs eventually.