### PR TITLE
Add timeout traversal to asynchronous edges

### DIFF
--- a/inngest/workflow.go
+++ b/inngest/workflow.go
@@ -103,7 +103,8 @@ type AsyncEdgeMetadata struct {
 	// If specified, the event name must match and this expression must evaluate
 	// to true for the workflow to continue.  This allows you to filter events
 	// to eg. the same user.
-	Match *string `json:"match"`
+	Match     *string `json:"match"`
+	OnTimeout bool    `json:"onTimeout"`
 }
 
 // VersionCoinstraint represents version constraints for an action.  We use semver without

--- a/internal/cuedefs/pkg/edges/edges.cue
+++ b/internal/cuedefs/pkg/edges/edges.cue
@@ -6,6 +6,7 @@ package edges
 	type:  "edge"
 	name?: string
 	if?:   string
+	wait?: string
 })
 
 // An AsyncEdge represents an edge that can be traversed at some future point in time
@@ -18,5 +19,8 @@ package edges
 		ttl:    string
 		event:  string
 		match?: string
+		// onTimeout specifies that this edge should be traversed on timeout only,
+		// if the event is not received within the TTL.
+		onTimeout?: bool
 	})
 })

--- a/pkg/cuedefs/v1/function.cue
+++ b/pkg/cuedefs/v1/function.cue
@@ -100,5 +100,8 @@ package v1
 		ttl:    string
 		event:  string
 		match?: string
+		// onTimeout specifies that this edge should be traversed on timeout only,
+		// if the event is not received within the TTL.
+		onTimeout?: bool
 	}
 }

--- a/pkg/execution/runner/runner.go
+++ b/pkg/execution/runner/runner.go
@@ -123,7 +123,6 @@ func (i *InMemoryRunner) run(ctx context.Context, item inmemory.QueueItem) error
 	}
 
 	for _, next := range children {
-
 		// We want to wait for another event to come in to traverse this edge within the DAG.
 		//
 		// Create a new "pause", which informs the state manager that we're pausing the traversal

--- a/pkg/execution/state/inmemory/inmemory_test.go
+++ b/pkg/execution/state/inmemory/inmemory_test.go
@@ -4,11 +4,14 @@ import (
 	"context"
 	"crypto/rand"
 	"testing"
+	"time"
 
 	"github.com/google/uuid"
+	"github.com/inngest/inngest-cli/inngest"
 	"github.com/inngest/inngest-cli/pkg/execution/state"
 	"github.com/oklog/ulid/v2"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func newULID() ulid.ULID {
@@ -17,7 +20,6 @@ func newULID() ulid.ULID {
 
 func TestInMemorySaveOutput(t *testing.T) {
 	ctx := context.Background()
-
 	sm := NewStateManager()
 
 	i := state.Identifier{
@@ -40,4 +42,88 @@ func TestInMemorySaveOutput(t *testing.T) {
 	assert.Equal(t, i.RunID, s.(*memstate).runID)
 	assert.Equal(t, 1, len(s.(*memstate).actions))
 	assert.Equal(t, data, s.(*memstate).actions["1"])
+}
+
+func TestInMemoryPause(t *testing.T) {
+	ctx := context.Background()
+	sm := NewStateManager()
+
+	s, err := sm.New(ctx, inngest.Workflow{}, ulid.MustNew(ulid.Now(), rand.Reader), map[string]any{})
+	require.NoError(t, err)
+
+	pauseID := uuid.New()
+
+	// Deleting a noneixstent pause should error.
+	err = sm.ConsumePause(ctx, pauseID)
+	require.ErrorIs(t, state.ErrPauseNotFound, err)
+
+	// Deleting a pause works as expected.
+	err = sm.SavePause(ctx, state.Pause{
+		ID:         pauseID,
+		Identifier: s.Identifier(),
+		// XXX: Right now, in memory state does not validate that the outgoing and
+		// incoming edges exist in the workflow, so this won't break.  Yet.
+		Outgoing: "a",
+		Incoming: "b",
+		Expires:  time.Now().Add(time.Second),
+	})
+	require.NoError(t, err)
+
+	err = sm.ConsumePause(ctx, pauseID)
+	require.NoError(t, err)
+
+	// And you can't re-consume pauses.
+	err = sm.ConsumePause(ctx, pauseID)
+	require.ErrorIs(t, err, state.ErrPauseNotFound)
+
+	// Create a new pause, and wait until the expires
+
+	pauseID = uuid.New()
+	err = sm.SavePause(ctx, state.Pause{
+		ID:         pauseID,
+		Identifier: s.Identifier(),
+		Outgoing:   "b",
+		Incoming:   "c",
+		Expires:    time.Now().Add(20 * time.Millisecond),
+	})
+	require.NoError(t, err)
+	<-time.After(21 * time.Millisecond)
+
+	// The pause should be "not found"
+	err = sm.ConsumePause(ctx, pauseID)
+	require.NotNil(t, err)
+	require.ErrorIs(t, err, state.ErrPauseNotFound)
+
+	// And finally, a pause that is OnTimeout should enqueue an edge.
+	pauseID = uuid.New()
+	pre := time.Now()
+	err = sm.SavePause(ctx, state.Pause{
+		ID:         pauseID,
+		Identifier: s.Identifier(),
+		Outgoing:   "c",
+		Incoming:   "d",
+		Expires:    time.Now().Add(20 * time.Millisecond),
+		OnTimeout:  true,
+	})
+	require.NoError(t, err)
+
+	select {
+	case next := <-sm.Channel():
+		require.WithinDuration(
+			t,
+			pre,
+			time.Now().Add(-20*time.Millisecond),
+			2*time.Millisecond,
+		)
+		require.EqualValues(
+			t,
+			inngest.Edge{
+				Outgoing: "c",
+				Incoming: "d",
+			},
+			next.Edge,
+		)
+	case <-time.After(time.Second):
+		t.Fatalf("Didn't receive enqueued item on pause timeout")
+	}
 }

--- a/pkg/execution/state/state.go
+++ b/pkg/execution/state/state.go
@@ -12,6 +12,7 @@ import (
 
 var (
 	ErrStepIncomplete = fmt.Errorf("step has not yet completed")
+	ErrPauseNotFound  = fmt.Errorf("pause not found")
 )
 
 // Identifier represents the unique identifier for a workflow run.
@@ -40,6 +41,9 @@ type Pause struct {
 	// Expression is an optional expression that must match for the pause
 	// to be resumed.
 	Expression *string `json:"expression"`
+	// OnTimeout indicates that this incoming edge should only be ran
+	// when the pause times out, if set to true.
+	OnTimeout bool `json:"onTimeout"`
 }
 
 // State represents the current state of a workflow.  It is data-structure


### PR DESCRIPTION
This PR allows users to specify async edges that are only traversed if
an async edge isn't matched after the TTL.

For example, if you want a user to perform an action within 5 minutes
then run a function when that _doesn't_ happen, this feature enables
such logic.