### PR TITLE
Include ActionVersion in driver.Response

### DIFF
--- a/pkg/execution/driver/dockerdriver/dockerdriver.go
+++ b/pkg/execution/driver/dockerdriver/dockerdriver.go
@@ -87,7 +87,8 @@ func (d *dockerExec) Execute(ctx context.Context, state state.State, action inng
 	}
 
 	resp := &driver.Response{
-		Output: map[string]interface{}{},
+		Output:        map[string]interface{}{},
+		ActionVersion: action.Version,
 	}
 	if exit != 0 {
 		resp.Err = fmt.Errorf("non-zero status code: %d", exit)

--- a/pkg/execution/driver/driver.go
+++ b/pkg/execution/driver/driver.go
@@ -28,6 +28,11 @@ type Response struct {
 	// Err represents the error from the action, if the action errored.
 	// If the action terminated successfully this must be nil.
 	Err error `json:"err"`
+
+	// ActionVersion returns the version of the action executed, as some workflows
+	// may have ranges.  This must be included in a driver.Response as this is the
+	// return result from an executor.
+	ActionVersion *inngest.VersionInfo `json:"actionVersion"`
 }
 
 // Retryable returns whether the response indicates that the action is

--- a/pkg/execution/driver/httpdriver/httpdriver.go
+++ b/pkg/execution/driver/httpdriver/httpdriver.go
@@ -78,6 +78,7 @@ func (e executor) Execute(ctx context.Context, state state.State, action inngest
 			"status": resp.StatusCode,
 			"body":   body,
 		},
-		Err: err,
+		Err:           err,
+		ActionVersion: action.Version,
 	}, nil
 }

--- a/pkg/execution/executor/executor.go
+++ b/pkg/execution/executor/executor.go
@@ -220,6 +220,12 @@ func (e *executor) executeAction(ctx context.Context, id state.Identifier, actio
 		return nil, fmt.Errorf("error executing action: %w", err)
 	}
 
+	if response.ActionVersion == nil {
+		// Set the ActionVersion automatically from the executor, where
+		// provided from the definition.
+		response.ActionVersion = definition.Version
+	}
+
 	// This action may have executed _asynchronously_.  That is, it may have been
 	// scheduled for execution but the result is pending.  In this case we cannot
 	// traverse this node's children as we don't have the response yet.

--- a/pkg/execution/executor/executor_test.go
+++ b/pkg/execution/executor/executor_test.go
@@ -294,9 +294,11 @@ func TestExecute_edge_expressions(t *testing.T) {
 	require.ElementsMatch(t, []string{}, availableIDs(edges))
 
 	// Run the next step.
-	_, err = exec.Execute(ctx, s.Identifier(), "run-step-trigger")
+	response, err := exec.Execute(ctx, s.Identifier(), "run-step-trigger")
 	assert.NoError(t, err)
 	assert.Equal(t, 1, len(driver.Executed))
+	assert.NoError(t, response.Err)
+	assert.EqualValues(t, *response, driver.Responses["run-step-trigger"])
 
 	s, err = sm.Load(ctx, s.Identifier())
 	require.NoError(t, err)


### PR DESCRIPTION
When a workflow includes version ranges to run, ensure we return the
specific action version that was executed.