### PR TITLE
Add step IDs to init-generated functions

### DIFF
--- a/pkg/cli/initialize_fn.go
+++ b/pkg/cli/initialize_fn.go
@@ -224,12 +224,13 @@ func (f *initModel) Function(ctx context.Context) (*function.Function, error) {
 			{CronTrigger: &function.CronTrigger{Cron: f.cron}},
 		}
 	default:
-		return fn, fmt.Errorf("Unknown trigger type: %s", f.triggerType)
+		return nil, fmt.Errorf("Unknown trigger type: %s", f.triggerType)
 	}
 
 	// If this is an HTTP function, set the runtime.
 	if f.runtimeType == runtimeHTTP {
-		fn.Steps[fn.Name] = function.Step{
+		fn.Steps[function.DefaultStepName] = function.Step{
+			ID:   function.DefaultStepName,
 			Name: fn.Name,
 			Runtime: inngest.RuntimeWrapper{
 				Runtime: inngest.RuntimeHTTP{
@@ -238,7 +239,8 @@ func (f *initModel) Function(ctx context.Context) (*function.Function, error) {
 			},
 		}
 	} else {
-		fn.Steps[fn.Name] = function.Step{
+		fn.Steps[function.DefaultStepName] = function.Step{
+			ID:   function.DefaultStepName,
 			Name: fn.Name,
 			Runtime: inngest.RuntimeWrapper{
 				Runtime: inngest.RuntimeDocker{},

--- a/pkg/cli/initialize_fn_test.go
+++ b/pkg/cli/initialize_fn_test.go
@@ -1,0 +1,74 @@
+package cli
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	"github.com/inngest/inngest-cli/inngest"
+	"github.com/inngest/inngest-cli/pkg/function"
+	"github.com/stretchr/testify/require"
+)
+
+func TestInitFunc(t *testing.T) {
+	tests := []struct {
+		name          string
+		i             *initModel
+		fn            *function.Function
+		err           error
+		validationErr error
+	}{
+		{
+			name: "bare init model",
+			i:    &initModel{},
+			err:  fmt.Errorf("Unknown trigger type: "),
+		},
+		{
+			name: "bare init model",
+			i: &initModel{
+				name:        "test fn",
+				triggerType: "Event based",
+				event:       "test/some-event",
+			},
+			fn: &function.Function{
+				Name: "test fn",
+				Triggers: []function.Trigger{
+					{
+						EventTrigger: &function.EventTrigger{
+							Event: "test/some-event",
+						},
+					},
+				},
+				Steps: map[string]function.Step{
+					function.DefaultStepName: function.Step{
+						ID:   function.DefaultStepName,
+						Name: "test fn",
+						Runtime: inngest.RuntimeWrapper{
+							Runtime: inngest.RuntimeDocker{},
+						},
+					},
+				},
+			},
+		},
+	}
+	ctx := context.Background()
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			fn, err := test.i.Function(ctx)
+			require.EqualValues(t, test.err, err)
+
+			if fn != nil {
+				// IDs are always randomly generated, so we can't assert that
+				// here.  Update the ID of the test.
+				test.fn.ID = fn.ID
+			}
+
+			require.EqualValues(t, test.fn, fn)
+			if fn != nil {
+				err := fn.Validate(ctx)
+				require.EqualValues(t, test.validationErr, err)
+			}
+		})
+	}
+}

--- a/pkg/function/config_test.go
+++ b/pkg/function/config_test.go
@@ -85,8 +85,8 @@ func TestUnmarshal(t *testing.T) {
 					{EventTrigger: &EventTrigger{Event: "test.event"}},
 				},
 				Steps: map[string]Step{
-					defaultStepName: {
-						ID:   defaultStepName,
+					DefaultStepName: {
+						ID:   DefaultStepName,
 						Name: "test",
 						Runtime: inngest.RuntimeWrapper{
 							Runtime: inngest.RuntimeDocker{},
@@ -118,8 +118,8 @@ func TestUnmarshal(t *testing.T) {
 					{EventTrigger: &EventTrigger{Event: "test.event"}},
 				},
 				Steps: map[string]Step{
-					defaultStepName: {
-						ID:   defaultStepName,
+					DefaultStepName: {
+						ID:   DefaultStepName,
 						Name: "test",
 						Runtime: inngest.RuntimeWrapper{
 							Runtime: inngest.RuntimeDocker{},
@@ -156,8 +156,8 @@ func TestUnmarshal(t *testing.T) {
 					{EventTrigger: &EventTrigger{Event: "test.event"}},
 				},
 				Steps: map[string]Step{
-					defaultStepName: {
-						ID:   defaultStepName,
+					DefaultStepName: {
+						ID:   DefaultStepName,
 						Name: "test",
 						Runtime: inngest.RuntimeWrapper{
 							Runtime: inngest.RuntimeDocker{},

--- a/pkg/function/function.go
+++ b/pkg/function/function.go
@@ -17,7 +17,7 @@ import (
 )
 
 const (
-	defaultStepName = "step-function"
+	DefaultStepName = "step-1"
 )
 
 // Function represents a step function which is triggered whenever an event
@@ -322,8 +322,8 @@ func (f *Function) canonicalize(ctx context.Context, path string) error {
 		// custom code with the docker executor, and that the code is
 		// in the current directory.
 		f.Steps = map[string]Step{}
-		f.Steps["step-function"] = Step{
-			ID:   "step-function",
+		f.Steps[DefaultStepName] = Step{
+			ID:   DefaultStepName,
 			Name: f.Name,
 			Runtime: inngest.RuntimeWrapper{
 				Runtime: inngest.RuntimeDocker{},

--- a/pkg/function/function_test.go
+++ b/pkg/function/function_test.go
@@ -42,7 +42,7 @@ func TestDerivedConfigDefault(t *testing.T) {
 
 	expectedActionVersion := inngest.ActionVersion{
 		Name:   "Foo",
-		DSN:    "magical-id-step-step-function-test",
+		DSN:    "magical-id-step-step-1-test",
 		Scopes: []string{"secret:read:*"},
 		Runtime: inngest.RuntimeWrapper{
 			Runtime: inngest.RuntimeDocker{},
@@ -57,7 +57,7 @@ import (
 
 action: actions.#Action
 action: {
-  dsn:  "magical-id-step-step-function-test"
+  dsn:  "magical-id-step-step-1-test"
   name: "Foo"
   scopes: ["secret:read:*"]
   runtime: type: "docker"
@@ -86,7 +86,7 @@ action: {
 		},
 		Steps: []inngest.Step{
 			{
-				ID:       defaultStepName,
+				ID:       DefaultStepName,
 				ClientID: 1,
 				Name:     expectedActionVersion.Name,
 				DSN:      expectedActionVersion.DSN,
@@ -95,7 +95,7 @@ action: {
 		Edges: []inngest.Edge{
 			{
 				Outgoing: inngest.TriggerName,
-				Incoming: defaultStepName,
+				Incoming: DefaultStepName,
 			},
 		},
 	}
@@ -114,14 +114,14 @@ workflow: workflows.#Workflow & {
     expression: "event.version >= 2"
   }]
   actions: [{
-    id:       "step-function"
+    id:       "step-1"
     clientID: 1
     name:     "Foo"
-    dsn:      "magical-id-step-step-function-test"
+    dsn:      "magical-id-step-step-1-test"
   }]
   edges: [{
     outgoing: "$trigger"
-    incoming: "step-function"
+    incoming: "step-1"
     metadata: {}
   }]
 }`


### PR DESCRIPTION
This commit ensures that steps generated via `inngest init` have a step
ID included