### PR TITLE
Scaffold functions using steps

### DIFF
--- a/cmd/commands/init.go
+++ b/cmd/commands/init.go
@@ -74,7 +74,13 @@ func runInit(cmd *cobra.Command, args []string) {
 		// Use a blank template with no fs.FS to render only the JSON into the directory.
 		tpl = &scaffold.Template{}
 	}
-	if err := tpl.Render(*fn); err != nil {
+
+	var step function.Step
+	for _, v := range fn.Steps {
+		step = v
+	}
+
+	if err := tpl.Render(*fn, step); err != nil {
 		fmt.Println(cli.RenderError(fmt.Sprintf("There was an error creating the function: %s", err)) + "\n")
 		return
 	}

--- a/cmd/commands/run.go
+++ b/cmd/commands/run.go
@@ -48,6 +48,7 @@ func doRun(cmd *cobra.Command, args []string) {
 
 	if err = buildImg(cmd.Context(), *fn); err != nil {
 		// This should already have been printed to the terminal.
+		fmt.Println("\n" + cli.RenderError(err.Error()) + "\n")
 		os.Exit(1)
 	}
 
@@ -73,12 +74,10 @@ func buildImg(ctx context.Context, fn function.Function) error {
 		BuildOpts:      opts,
 	})
 	if err != nil {
-		fmt.Println("\n" + cli.RenderError(err.Error()) + "\n")
-		os.Exit(1)
+		return err
 	}
 	if err := tea.NewProgram(ui).Start(); err != nil {
-		fmt.Println("\n" + cli.RenderError(err.Error()) + "\n")
-		os.Exit(1)
+		return err
 	}
 	return ui.Error()
 }

--- a/pkg/cli/initialize_fn.go
+++ b/pkg/cli/initialize_fn.go
@@ -232,6 +232,7 @@ func (f *initModel) Function(ctx context.Context) (*function.Function, error) {
 		fn.Steps[function.DefaultStepName] = function.Step{
 			ID:   function.DefaultStepName,
 			Name: fn.Name,
+			Path: function.DefaultStepPath,
 			Runtime: inngest.RuntimeWrapper{
 				Runtime: inngest.RuntimeHTTP{
 					URL: f.url,
@@ -242,6 +243,7 @@ func (f *initModel) Function(ctx context.Context) (*function.Function, error) {
 		fn.Steps[function.DefaultStepName] = function.Step{
 			ID:   function.DefaultStepName,
 			Name: fn.Name,
+			Path: function.DefaultStepPath,
 			Runtime: inngest.RuntimeWrapper{
 				Runtime: inngest.RuntimeDocker{},
 			},

--- a/pkg/cli/initialize_fn_test.go
+++ b/pkg/cli/initialize_fn_test.go
@@ -40,9 +40,10 @@ func TestInitFunc(t *testing.T) {
 					},
 				},
 				Steps: map[string]function.Step{
-					function.DefaultStepName: function.Step{
+					function.DefaultStepName: {
 						ID:   function.DefaultStepName,
 						Name: "test fn",
+						Path: function.DefaultStepPath,
 						Runtime: inngest.RuntimeWrapper{
 							Runtime: inngest.RuntimeDocker{},
 						},

--- a/pkg/devserver/engine.go
+++ b/pkg/devserver/engine.go
@@ -122,7 +122,7 @@ func (eng *Engine) SetFunctions(ctx context.Context, functions []*function.Funct
 
 	// Build all function images.
 	if err := eng.buildImages(ctx); err != nil {
-		return err
+		return fmt.Errorf("error building images: %w", err)
 	}
 
 	// If a previous cron manager exists, cancel it.

--- a/pkg/function/config_test.go
+++ b/pkg/function/config_test.go
@@ -88,6 +88,7 @@ func TestUnmarshal(t *testing.T) {
 					DefaultStepName: {
 						ID:   DefaultStepName,
 						Name: "test",
+						Path: "file://.",
 						Runtime: inngest.RuntimeWrapper{
 							Runtime: inngest.RuntimeDocker{},
 						},
@@ -121,6 +122,7 @@ func TestUnmarshal(t *testing.T) {
 					DefaultStepName: {
 						ID:   DefaultStepName,
 						Name: "test",
+						Path: "file://.",
 						Runtime: inngest.RuntimeWrapper{
 							Runtime: inngest.RuntimeDocker{},
 						},
@@ -159,6 +161,7 @@ func TestUnmarshal(t *testing.T) {
 					DefaultStepName: {
 						ID:   DefaultStepName,
 						Name: "test",
+						Path: "file://.",
 						Runtime: inngest.RuntimeWrapper{
 							Runtime: inngest.RuntimeDocker{},
 						},

--- a/pkg/function/event_definition.go
+++ b/pkg/function/event_definition.go
@@ -20,8 +20,6 @@ const (
 	// FormatJSONSchema specifies that the event type is valid JSON Schema
 	FormatJSONSchema = "json-schema"
 
-	FilePrefix = "file://"
-
 	// eventIdentifier is the identifier used within cue to declare the event's type.
 	eventIdentifier = "InngestEvent"
 )
@@ -68,17 +66,15 @@ func (ed *EventDefinition) createCueType() error {
 		return nil
 	}
 
-	if strings.HasPrefix(ed.Def, FilePrefix) {
-		path := strings.Replace(ed.Def, FilePrefix, "", 1)
-
-		file, err := filepath.Abs(path)
-		if err != nil {
-			return fmt.Errorf("error determining event definition path: %w", err)
-		}
+	if file, _ := PathName(ed.Def); file != "" {
 		// The event definition is stored within a file.
+		file, err := filepath.Abs(file)
+		if err != nil {
+			return fmt.Errorf("error finding event definition: %w", err)
+		}
 		byt, err := os.ReadFile(file)
 		if err != nil {
-			return fmt.Errorf("error reading event definition '%s': %w", path, err)
+			return fmt.Errorf("error reading event definition '%s': %w", file, err)
 		}
 		ed.Def = string(byt)
 	}

--- a/pkg/function/path.go
+++ b/pkg/function/path.go
@@ -1,0 +1,24 @@
+package function
+
+import (
+	"fmt"
+	"strings"
+)
+
+const (
+	FilePrefix = "file://"
+)
+
+var (
+	ErrNoPath = fmt.Errorf("the provided path could not be parsed")
+
+	DefaultStepPath = fmt.Sprintf("%s./steps/%s", FilePrefix, DefaultStepName)
+)
+
+// PathName returns the path as defined with the "file://" prefix removed.
+func PathName(path string) (string, error) {
+	if !strings.HasPrefix(path, FilePrefix) {
+		return "", ErrNoPath
+	}
+	return strings.Replace(path, FilePrefix, "", 1), nil
+}

--- a/pkg/scaffold/template_test.go
+++ b/pkg/scaffold/template_test.go
@@ -6,6 +6,7 @@ import (
 	"path/filepath"
 	"testing"
 
+	"github.com/inngest/inngest-cli/inngest"
 	"github.com/inngest/inngest-cli/pkg/function"
 	"github.com/stretchr/testify/require"
 )
@@ -62,14 +63,26 @@ func TestTemplateRenderTypescript(t *testing.T) {
 		},
 	)
 
+	f.Steps["test"] = function.Step{
+		ID:   "test",
+		Path: "file://./steps/my-test",
+		Name: "A test function 😋",
+		Runtime: inngest.RuntimeWrapper{
+			Runtime: inngest.RuntimeDocker{},
+		},
+		After: []function.After{
+			{Step: inngest.TriggerName},
+		},
+	}
+
 	root, _ := filepath.Abs("./" + f.Slug())
 	os.RemoveAll(root)
 
-	err = tpl.Render(*f)
+	err = tpl.Render(*f, f.Steps["test"])
 	require.NoError(t, err)
 
 	// Expect "types.ts" to contain genned types.
-	byt, err := os.ReadFile(filepath.Join(root, "types.ts"))
+	byt, err := os.ReadFile(filepath.Join(root, "steps", "my-test", "types.ts"))
 	require.NoError(t, err)
 	require.EqualValues(t, expectedTypes, string(byt))
 }


### PR DESCRIPTION
This PR ensures that we always `init` functions using a structure
suitable for step functions.  Instead of dumping a scaffold within the
root fn dir, we now create:

- `./events`, which contains event definitions using CUE types
- `./steps`, which holds the source for each step definition.

This allows us to create many steps for a single function without
complicating the root dir.

We also fix several issues relating to docker builds with multiple
steps, and tidy some logic for working with paths.