### PR TITLE
Add --event flag to `inngest init`

### DIFF
--- a/cmd/commands/init.go
+++ b/cmd/commands/init.go
@@ -21,6 +21,9 @@ func NewCmdInit() *cobra.Command {
 		Example: "inngestctl init",
 		Run:     runInit,
 	}
+
+	cmd.Flags().String("event", "", "An optional event name which triggers the function")
+
 	return cmd
 }
 
@@ -43,6 +46,7 @@ func runInit(cmd *cobra.Command, args []string) {
 	// the walkthrough is complete, this blocks and returns.
 	state, err := cli.NewInitModel(cli.InitOpts{
 		ShowWelcome: showWelcome,
+		Event:       cmd.Flag("event").Value.String(),
 	})
 	if err != nil {
 		fmt.Println(cli.RenderError(fmt.Sprintf("Error starting init command: %s", err)) + "\n")

--- a/pkg/cli/initialize_fn_test.go
+++ b/pkg/cli/initialize_fn_test.go
@@ -27,7 +27,7 @@ func TestInitFunc(t *testing.T) {
 			name: "bare init model",
 			i: &initModel{
 				name:        "test fn",
-				triggerType: "Event based",
+				triggerType: triggerTypeEvent,
 				event:       "test/some-event",
 			},
 			fn: &function.Function{
@@ -40,7 +40,7 @@ func TestInitFunc(t *testing.T) {
 					},
 				},
 				Steps: map[string]function.Step{
-					function.DefaultStepName: function.Step{
+					function.DefaultStepName: {
 						ID:   function.DefaultStepName,
 						Name: "test fn",
 						Runtime: inngest.RuntimeWrapper{


### PR DESCRIPTION
This flag allows users to specify events via the CLI when initializing
functions, skipping the trigger and event questions.