### PR TITLE
Always build on linux/x86 when deploying

### DIFF
--- a/cmd/commands/deploy.go
+++ b/cmd/commands/deploy.go
@@ -48,7 +48,7 @@ func deployFunction(cmd *cobra.Command, args []string) error {
 	}
 
 	// Build all steps.
-	steps, err := dockerdriver.FnBuildOpts(ctx, *fn)
+	steps, err := dockerdriver.FnBuildOpts(ctx, *fn, "--platform", "linux/amd64")
 	if err != nil {
 		return err
 	}

--- a/pkg/execution/driver/dockerdriver/build.go
+++ b/pkg/execution/driver/dockerdriver/build.go
@@ -25,7 +25,7 @@ type Artifact struct {
 	Tag  string
 }
 
-func FnBuildOpts(ctx context.Context, f function.Function) ([]BuildOpts, error) {
+func FnBuildOpts(ctx context.Context, f function.Function, args ...string) ([]BuildOpts, error) {
 	opts := []BuildOpts{}
 	for _, step := range f.Steps {
 		var err error
@@ -46,6 +46,7 @@ func FnBuildOpts(ctx context.Context, f function.Function) ([]BuildOpts, error) 
 		opts = append(opts, BuildOpts{
 			Path: path,
 			Tag:  step.DSN(ctx, f),
+			Args: args,
 		})
 	}
 


### PR DESCRIPTION
Primary runtimes for functions are x86.