### PR TITLE
Add version cmd to output

### DIFF
--- a/cmd/commands/root.go
+++ b/cmd/commands/root.go
@@ -49,6 +49,7 @@ func Execute() {
 	rootCmd.AddCommand(NewCmdDeploy())
 	rootCmd.AddCommand(NewCmdActions())
 	rootCmd.AddCommand(NewCmdDev())
+	rootCmd.AddCommand(NewCmdVersion())
 
 	if err := rootCmd.Execute(); err != nil {
 		fmt.Println(err)

--- a/cmd/commands/version.go
+++ b/cmd/commands/version.go
@@ -1,0 +1,21 @@
+package commands
+
+import (
+	"fmt"
+
+	"github.com/inngest/inngest-cli/inngest/version"
+	"github.com/spf13/cobra"
+)
+
+func NewCmdVersion() *cobra.Command {
+	return &cobra.Command{
+		Use: "version",
+		Short: fmt.Sprintf(
+			"Shows the inngest CLI version (saving time, it's: %s)",
+			version.Print(),
+		),
+		Run: func(cmd *cobra.Command, args []string) {
+			fmt.Println(version.Print())
+		},
+	}
+}

--- a/inngest/version/version.go
+++ b/inngest/version/version.go
@@ -1,6 +1,12 @@
 package version
 
+import "fmt"
+
 var (
 	Version = "dev"
 	Hash    = ""
 )
+
+func Print() string {
+	return fmt.Sprintf("%s-%s", Version, Hash)
+}


### PR DESCRIPTION
Also show the version on run:
```
% inngest

    ____                            __
   /  _/___  ____  ____ ____  _____/ /_
   / // __ \/ __ \/ __ '/ _ \/ ___/ __/
 _/ // / / / / / / /_/ /  __(__  ) /_
/___/_/ /_/_/ /_/\__, /\___/____/\__/
                /____/

Usage:
  inngest [command]

Available Commands:
  completion  Generate the autocompletion script for the specified shell
  deploy      Deploy a function to Inngest
  dev         Run the inngest dev server
  help        Help about any command
  init        Create a new serverless function
  login       Logs in to your Inngest account
  run         Run a serverless function locally
  version     Shows the inngest CLI version (saving time, it's: v0.2.2-next-488a7f1)

Flags:
  -h, --help   help for inngest
      --json   Output logs as JSON.  Set to true if stdout is not a TTY.
      --prod   Use the production environment for the current command.
```