### PR TITLE
Add pause querying, pause iterator, in-memory, and redis implementation

### DIFF
--- a/pkg/devserver/engine.go
+++ b/pkg/devserver/engine.go
@@ -235,13 +235,17 @@ func (eng *Engine) HandleEvent(ctx context.Context, evt *event.Event) error {
 }
 
 func (eng *Engine) handlePauses(ctx context.Context, evt *event.Event) error {
-	for _, pause := range eng.sm.Pauses() {
-		if pause.Event == nil || *pause.Event != evt.Name {
-			continue
-		}
-		if pause.Expires.Before(time.Now()) {
-			continue
-		}
+	if evt == nil {
+		return nil
+	}
+	it, err := eng.sm.PausesByEvent(ctx, evt.Name)
+	if err != nil {
+		return err
+	}
+
+	for it.Next(ctx) {
+		pause := it.Val(ctx)
+
 		if pause.Expression != nil {
 			s, err := eng.sm.Load(ctx, pause.Identifier)
 			if err != nil {

--- a/pkg/devserver/engine_test.go
+++ b/pkg/devserver/engine_test.go
@@ -119,7 +119,13 @@ func TestEngine_async(t *testing.T) {
 	require.Equal(t, "Basic step", driver.Executed["first"].Name)
 	// And we should have a pause.
 	require.Eventually(t, func() bool {
-		return len(e.sm.Pauses()) == 1
+		n := 0
+		iter, err := e.sm.PausesByEvent(ctx, "test/continue")
+		require.NoError(t, err)
+		for iter.Next(ctx) {
+			n++
+		}
+		return n == 1
 	}, 50*time.Millisecond, 10*time.Millisecond)
 
 	// 3.
@@ -134,7 +140,15 @@ func TestEngine_async(t *testing.T) {
 	require.NoError(t, err)
 	<-time.After(50 * time.Millisecond)
 	require.EqualValues(t, 1, len(driver.Executed))
-	require.EqualValues(t, 1, len(e.sm.Pauses()))
+	require.Eventually(t, func() bool {
+		n := 0
+		iter, err := e.sm.PausesByEvent(ctx, "test/continue")
+		require.NoError(t, err)
+		for iter.Next(ctx) {
+			n++
+		}
+		return n == 1
+	}, 50*time.Millisecond, 10*time.Millisecond)
 
 	// 4.
 	// Finally, assert that sending an event which matches the pause conditions

--- a/pkg/execution/executor/executor.go
+++ b/pkg/execution/executor/executor.go
@@ -46,9 +46,9 @@ var (
 // action has started.
 type Executor interface {
 	// Execute runs the given function via the execution drivers.  If the
-	// from ID is 0 this is treated as a new workflow invocation from the trigger,
-	// and all functions that are direct children of the trigger will be scheduled
-	// for execution.
+	// from ID is "$trigger" this is treated as a new workflow invocation from the
+	// trigger, and all functions that are direct children of the trigger will be
+	// scheduled for execution.
 	//
 	// It is important for this function to be atomic;  if the function was scheduled
 	// and the context terminates, we must store the output or async data in workflow

--- a/pkg/execution/runner/runner.go
+++ b/pkg/execution/runner/runner.go
@@ -106,10 +106,6 @@ func (i *InMemoryRunner) run(ctx context.Context, item inmemory.QueueItem) error
 		i.lock.RUnlock()
 	}()
 
-	// TODO: This could have been retried due to a state load error after
-	// the particular step's code has ran.  In this case, check that the
-	// function has no output stored.
-
 	resp, err := i.exec.Execute(ctx, item.ID, item.Edge.Incoming)
 	if err != nil {
 		// If the error is not of type response error, we can assume that this is

--- a/pkg/execution/state/inmemory/inmemory_test.go
+++ b/pkg/execution/state/inmemory/inmemory_test.go
@@ -15,7 +15,7 @@ import (
 )
 
 func TestStateHarness(t *testing.T) {
-	testharness.CheckState(t, NewStateManager())
+	testharness.CheckState(t, func() state.Manager { return NewStateManager() })
 }
 
 func TestInMemoryPause(t *testing.T) {
@@ -87,7 +87,7 @@ func TestInMemoryPause(t *testing.T) {
 			t,
 			pre,
 			time.Now().Add(-20*time.Millisecond),
-			2*time.Millisecond,
+			5*time.Millisecond,
 		)
 		require.EqualValues(
 			t,

--- a/pkg/execution/state/inmemory/pause_iterator.go
+++ b/pkg/execution/state/inmemory/pause_iterator.go
@@ -1,0 +1,37 @@
+package inmemory
+
+import (
+	"context"
+
+	"github.com/inngest/inngest-cli/pkg/execution/state"
+)
+
+type pauseIterator struct {
+	n      int
+	pauses []*state.Pause
+}
+
+// Next advances the iterator and returns whether the next call to Val will
+// return a non-nil pause.
+//
+// Next should be called prior to any call to the iterator's Val method, after
+// the iterator has been created.
+//
+// The order of the iterator is unspecified.
+func (p *pauseIterator) Next(ctx context.Context) bool {
+	p.n++
+	return len(p.pauses) > 0 && p.n <= len(p.pauses)
+}
+
+// Val returns the current Pause from the iterator.
+func (p *pauseIterator) Val(context.Context) *state.Pause {
+	if p.n > len(p.pauses) {
+		return nil
+	}
+	return p.pauses[p.n-1]
+}
+
+// Len returns the total number of items being iterated over.
+func (p *pauseIterator) Len() int {
+	return len(p.pauses)
+}

--- a/pkg/execution/state/redis_state/redis_state_test.go
+++ b/pkg/execution/state/redis_state/redis_state_test.go
@@ -5,14 +5,16 @@ import (
 
 	"github.com/alicebob/miniredis/v2"
 	"github.com/go-redis/redis/v8"
+	"github.com/inngest/inngest-cli/pkg/execution/state"
 	"github.com/inngest/inngest-cli/pkg/execution/state/testharness"
 )
 
 func TestStateHarness(t *testing.T) {
-	s := miniredis.RunT(t)
-	defer s.Close()
-	m := New(WithConnectOpts(redis.Options{
-		Addr: s.Addr(),
-	}))
-	testharness.CheckState(t, m)
+	create := func() state.Manager {
+		s := miniredis.RunT(t)
+		return New(WithConnectOpts(redis.Options{
+			Addr: s.Addr(),
+		}))
+	}
+	testharness.CheckState(t, create)
 }


### PR DESCRIPTION
This commit adds an interface for querying pauses from the state store.
There may be many pauses returned when querying by events, so we add an
Iterator interface which allows backing stores to return events without
storing the entire set in memory.

We also provide an in-memory implementation of the query interface and
iterator.

We will extend this to all implemented State interfaces in this PR.