### PR TITLE
Add ability to specify hostname to bind to when starting dev server

### DIFF
--- a/cmd/commands/dev.go
+++ b/cmd/commands/dev.go
@@ -17,6 +17,7 @@ func NewCmdDev() *cobra.Command {
 		Run:     doDev,
 	}
 
+	cmd.Flags().String("hostname", "", "hostname to run the API on")
 	cmd.Flags().StringP("port", "p", "9999", "port to run the API on")
 	cmd.Flags().String("dir", ".", "directory to load functions from")
 	return cmd
@@ -25,9 +26,10 @@ func NewCmdDev() *cobra.Command {
 func doDev(cmd *cobra.Command, args []string) {
 	ctx := cmd.Context()
 	devserver, err := devserver.NewDevServer(devserver.Options{
-		Port: cmd.Flag("port").Value.String(),
-		Dir:  cmd.Flag("dir").Value.String(),
-		Log:  log.Default(),
+		Hostname: cmd.Flag("hostname").Value.String(),
+		Port:     cmd.Flag("port").Value.String(),
+		Dir:      cmd.Flag("dir").Value.String(),
+		Log:      log.Default(),
 	})
 	if err != nil {
 		fmt.Println(err)

--- a/pkg/devserver/devserver.go
+++ b/pkg/devserver/devserver.go
@@ -8,9 +8,10 @@ import (
 )
 
 type Options struct {
-	Port string
-	Log  *zerolog.Logger
-	Dir  string
+	Hostname string
+	Port     string
+	Log      *zerolog.Logger
+	Dir      string
 }
 
 type DevServer struct {
@@ -28,6 +29,7 @@ func NewDevServer(o Options) (DevServer, error) {
 		return DevServer{}, err
 	}
 	api, err := api.NewAPI(api.Options{
+		Hostname:     o.Hostname,
 		Port:         o.Port,
 		EventHandler: eng.HandleEvent,
 		Logger:       o.Log,


### PR DESCRIPTION
Aiming to close #113.

- Adds a new `hostname` flag to `inngest dev`
- Passes through hostname to `http.ListenAndServe()`