### PR TITLE
Generic queue interface

### DIFF
--- a/pkg/devserver/devserver.go
+++ b/pkg/devserver/devserver.go
@@ -48,11 +48,18 @@ func NewDevServer(o Options) (DevServer, error) {
 }
 
 func (d DevServer) Start(ctx context.Context) error {
+	go func() {
+		if err := d.Engine.Start(ctx); err != nil {
+			panic("unable to start runner")
+		}
+	}()
+
 	err := d.Engine.Load(ctx, d.dir)
 	if err != nil {
 		d.log.Error().Msg(err.Error())
 		return err
 	}
+
 	err = d.API.Start(ctx)
 	if err != nil {
 		d.log.Error().Msg(err.Error())

--- a/pkg/devserver/engine_test.go
+++ b/pkg/devserver/engine_test.go
@@ -88,6 +88,12 @@ func TestEngine_async(t *testing.T) {
 	e.setExecutor(exec)
 	require.NoError(t, err, "couldn't set mock driver")
 
+	go func() {
+		// Start the engine.
+		err := e.Start(ctx)
+		require.NoError(t, err)
+	}()
+
 	// 1.
 	// Send an event that does nothing, and assert nothing runs.
 	err = e.HandleEvent(ctx, &event.Event{

--- a/pkg/devserver/logging_queue.go
+++ b/pkg/devserver/logging_queue.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"time"
 
+	"github.com/inngest/inngest-cli/pkg/execution/queue"
 	"github.com/inngest/inngest-cli/pkg/execution/state"
 	"github.com/inngest/inngest-cli/pkg/execution/state/inmemory"
 	"github.com/rs/zerolog"
@@ -26,15 +27,14 @@ type loggingQueue struct {
 	log *zerolog.Logger
 }
 
-func (l loggingQueue) Enqueue(item inmemory.QueueItem, at time.Time) {
+func (l loggingQueue) Enqueue(ctx context.Context, item queue.Item, at time.Time) error {
 	l.log.Info().
-		Str("run_id", item.ID.RunID.String()).
-		Str("step", item.Edge.Incoming).
-		Interface("edge", item.Edge).
+		Str("run_id", item.Identifier.RunID.String()).
+		Interface("payload", item.Payload).
 		Interface("error_count", item.ErrorCount).
 		Interface("at", at).
 		Msg("enqueueing step")
-	l.Queue.Enqueue(item, at)
+	return l.Queue.Enqueue(ctx, item, at)
 }
 
 func (l loggingQueue) SaveResponse(ctx context.Context, i state.Identifier, r state.DriverResponse, attempt int) (state.State, error) {

--- a/pkg/execution/queue/item.go
+++ b/pkg/execution/queue/item.go
@@ -1,0 +1,38 @@
+package queue
+
+import (
+	"fmt"
+
+	"github.com/inngest/inngest-cli/inngest"
+	"github.com/inngest/inngest-cli/pkg/execution/state"
+)
+
+// Item represents an item stored within a queue.
+//
+// Note that each individual implementation may wrap this to add their own fields,
+// such as a job identifier.
+type Item struct {
+	// Identifier represents the unique workflow ID and run ID for the current job.
+	Identifier state.Identifier
+	// ErrorCount stores the total number of errors that this job has currently procesed.
+	ErrorCount int
+	// Payload stores item-specific data for use when processing the item.  For example,
+	// this may contain the function's edge for running a step.
+	Payload any
+}
+
+// GetEdge returns the edge from the enqueued item, if the payload is of type PayloadEdge.
+func GetEdge(i Item) (*inngest.Edge, error) {
+	switch v := i.Payload.(type) {
+	case PayloadEdge:
+		return &v.Edge, nil
+	default:
+		return nil, fmt.Errorf("unable to get edge from payload type: %T", v)
+	}
+}
+
+// PayloadEdge is the payload stored when enqueueing an edge traversal to execute
+// the incoming step of the edge.
+type PayloadEdge struct {
+	Edge inngest.Edge
+}

--- a/pkg/execution/queue/queue.go
+++ b/pkg/execution/queue/queue.go
@@ -1,0 +1,25 @@
+package queue
+
+import (
+	"context"
+	"time"
+)
+
+type Queue interface {
+	Producer
+	Consumer
+}
+
+type Producer interface {
+	// Enqueue allows an item to be enqueued ton run at the given time.
+	Enqueue(context.Context, Item, time.Time) error
+}
+
+type Consumer interface {
+	// Run is a blocking function which listens to the queue and executes the
+	// given function each time a new Item becomes available.
+	//
+	// This must only return an error if we fail to subscribe to the queue's
+	// implementation and can no longer process jobs.
+	Run(context.Context, func(context.Context, Item) error) error
+}

--- a/pkg/execution/runner/runner.go
+++ b/pkg/execution/runner/runner.go
@@ -6,17 +6,21 @@ import (
 	"context"
 	"crypto/rand"
 	"fmt"
-	"sync"
 	"time"
 
 	"github.com/google/uuid"
 	"github.com/inngest/inngest-cli/inngest"
 	"github.com/inngest/inngest-cli/pkg/backoff"
 	"github.com/inngest/inngest-cli/pkg/execution/executor"
+	"github.com/inngest/inngest-cli/pkg/execution/queue"
 	"github.com/inngest/inngest-cli/pkg/execution/state"
 	"github.com/inngest/inngest-cli/pkg/execution/state/inmemory"
 	"github.com/oklog/ulid/v2"
 	"github.com/xhit/go-str2duration/v2"
+)
+
+var (
+	CompletePollInterval = 25 * time.Millisecond
 )
 
 // New returns a new runner which executes workflows in-memory.  This is NOT, EVER, IN
@@ -25,23 +29,23 @@ import (
 func NewInMemoryRunner(sm inmemory.Queue, exec executor.Executor) *InMemoryRunner {
 	return &InMemoryRunner{
 		sm:    sm,
+		queue: sm,
 		exec:  exec,
-		waits: map[ulid.ULID]*sync.WaitGroup{},
-		lock:  &sync.RWMutex{},
 	}
 }
 
 // InMemoryRunner represents a runner which coordinates steps enqueued within an
 // in memory queue, and executing the steps within the executor.
 type InMemoryRunner struct {
-	sm   inmemory.Queue
-	exec executor.Executor
+	sm    state.Manager
+	queue queue.Queue
+	exec  executor.Executor
+}
 
-	// In a dev server, we want to wait until all current steps of a state.Identifier
-	// are complete.  We create a new waitgroup per identifier to wait for the steps.
-	waits map[ulid.ULID]*sync.WaitGroup
-
-	lock *sync.RWMutex
+// Start invokes the queue's Run function blocking and reading items from the queue
+// for processing.
+func (i *InMemoryRunner) Start(ctx context.Context) error {
+	return i.queue.Run(ctx, i.run)
 }
 
 // NewRun initializes a new run for the given workflow.
@@ -52,61 +56,54 @@ func (i *InMemoryRunner) NewRun(ctx context.Context, f inngest.Workflow, data ma
 	}
 	id := state.Identifier()
 
-	i.Enqueue(ctx, inmemory.QueueItem{
-		ID:   id,
-		Edge: inngest.SourceEdge,
+	err = i.Enqueue(ctx, queue.Item{
+		Identifier: id,
+		Payload:    queue.PayloadEdge{Edge: inngest.SourceEdge},
 	}, time.Now())
 
-	return &id, nil
+	return &id, err
 }
 
-func (i InMemoryRunner) Enqueue(ctx context.Context, item inmemory.QueueItem, at time.Time) {
-	if _, ok := i.waits[item.ID.RunID]; !ok {
-		i.lock.Lock()
-		i.waits[item.ID.RunID] = &sync.WaitGroup{}
-		i.lock.Unlock()
+// Wait blocks until the given run has finished.
+func (i InMemoryRunner) Wait(ctx context.Context, id state.Identifier) error {
+	// TODO: Implement subscribe if the state store has a subscribe method.
+	for {
+		select {
+		case <-time.After(CompletePollInterval):
+			ok, err := i.sm.IsComplete(ctx, id)
+			if err != nil {
+				return err
+			}
+			if ok {
+				return nil
+			}
+		case <-ctx.Done():
+			return nil
+		}
+	}
+}
+
+func (i InMemoryRunner) Enqueue(ctx context.Context, item queue.Item, at time.Time) error {
+	edge, err := queue.GetEdge(item)
+	if err != nil {
+		return err
 	}
 
-	// Add to the waitgroup, ensuring that the runner blocks until the enqueued item
-	// is finished.
-	i.lock.RLock()
-	wg := i.waits[item.ID.RunID]
-	i.lock.RUnlock()
-
-	wg.Add(1)
-
-	i.sm.Enqueue(item, at)
-	i.sm.Scheduled(ctx, item.ID, item.Edge.Incoming)
+	if err := i.queue.Enqueue(ctx, item, at); err != nil {
+		return err
+	}
+	_ = i.sm.Scheduled(ctx, item.Identifier, edge.Incoming)
+	return nil
 }
 
-// Execute runs all available tasks, blocking until terminated.
-func (i *InMemoryRunner) Execute(ctx context.Context, id state.Identifier) error {
-	var err error
-	go func() {
-		for item := range i.sm.Channel() {
-			// We could terminate the executor here on error
-			_ = i.run(ctx, item)
-		}
-	}()
+// run coordinates the execution of items from the queue.
+func (i *InMemoryRunner) run(ctx context.Context, item queue.Item) error {
+	edge, err := queue.GetEdge(item)
+	if err != nil {
+		return err
+	}
 
-	// Wait for all items in the queue to be complete.
-	i.lock.RLock()
-	wg := i.waits[id.RunID]
-	i.lock.RUnlock()
-
-	wg.Wait()
-
-	return err
-}
-
-func (i *InMemoryRunner) run(ctx context.Context, item inmemory.QueueItem) error {
-	defer func() {
-		i.lock.RLock()
-		i.waits[item.ID.RunID].Done()
-		i.lock.RUnlock()
-	}()
-
-	resp, err := i.exec.Execute(ctx, item.ID, item.Edge.Incoming, item.ErrorCount)
+	resp, err := i.exec.Execute(ctx, item.Identifier, edge.Incoming, item.ErrorCount)
 	if err != nil {
 		// If the error is not of type response error, we can assume that this is
 		// always retryable.
@@ -115,31 +112,24 @@ func (i *InMemoryRunner) run(ctx context.Context, item inmemory.QueueItem) error
 			next := item
 			next.ErrorCount += 1
 			at := backoff.LinearJitterBackoff(next.ErrorCount)
-
-			// XXX: When we add max retries to steps, read the step from the
-			// state store here to chech for the step's retry data.
-			//
-			// For now, we retry steps of a function up to 3 times.
-			if next.ErrorCount < 3 {
-				// Retry this item.
-				i.Enqueue(ctx, next, at)
+			if err := i.Enqueue(ctx, next, at); err != nil {
 				return err
 			}
 		}
 
 		// This is a non-retryable error.  Finalize this step.
-		if err := i.sm.Finalized(ctx, item.ID, item.Edge.Incoming); err != nil {
+		if err := i.sm.Finalized(ctx, item.Identifier, edge.Incoming); err != nil {
 			return err
 		}
 		return fmt.Errorf("execution error: %s", err)
 	}
 
-	s, err := i.sm.Load(ctx, item.ID)
+	s, err := i.sm.Load(ctx, item.Identifier)
 	if err != nil {
 		return err
 	}
 
-	children, err := state.DefaultEdgeEvaluator.AvailableChildren(ctx, s, item.Edge.Incoming)
+	children, err := state.DefaultEdgeEvaluator.AvailableChildren(ctx, s, edge.Incoming)
 	if err != nil {
 		return err
 	}
@@ -187,17 +177,19 @@ func (i *InMemoryRunner) run(ctx context.Context, item inmemory.QueueItem) error
 		}
 
 		// Enqueue the next child in our in-memory state queue.
-		i.Enqueue(ctx, inmemory.QueueItem{
-			ID:   item.ID,
-			Edge: next,
-		}, at)
+		if err := i.Enqueue(ctx, queue.Item{
+			Identifier: item.Identifier,
+			Payload:    queue.PayloadEdge{Edge: next},
+		}, at); err != nil {
+			return err
+		}
 	}
 
 	// Mark this step as finalized.
 	//
 	// This must happen after everything is enqueued, else the scheduled <> finalized count
 	// is out of order.
-	if err := i.sm.Finalized(ctx, item.ID, item.Edge.Incoming); err != nil {
+	if err := i.sm.Finalized(ctx, item.Identifier, edge.Incoming); err != nil {
 		return err
 	}
 

--- a/pkg/execution/state/inmemory/inmemory_test.go
+++ b/pkg/execution/state/inmemory/inmemory_test.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/google/uuid"
 	"github.com/inngest/inngest-cli/inngest"
+	"github.com/inngest/inngest-cli/pkg/execution/queue"
 	"github.com/inngest/inngest-cli/pkg/execution/state"
 	"github.com/inngest/inngest-cli/pkg/execution/state/testharness"
 	"github.com/oklog/ulid/v2"
@@ -95,7 +96,7 @@ func TestInMemoryPause(t *testing.T) {
 				Outgoing: "c",
 				Incoming: "d",
 			},
-			next.Edge,
+			next.Payload.(queue.PayloadEdge).Edge,
 		)
 	case <-time.After(time.Second):
 		t.Fatalf("Didn't receive enqueued item on pause timeout")

--- a/pkg/execution/state/redis_state/redis_state.go
+++ b/pkg/execution/state/redis_state/redis_state.go
@@ -186,6 +186,14 @@ func (m mgr) New(ctx context.Context, workflow inngest.Workflow, runID ulid.ULID
 		nil
 }
 
+func (m mgr) IsComplete(ctx context.Context, id state.Identifier) (bool, error) {
+	val, err := m.r.HGet(ctx, m.kf.RunMetadata(ctx, id), "pending").Result()
+	if err != nil {
+		return false, err
+	}
+	return val == "0", nil
+}
+
 func (m mgr) metadata(ctx context.Context, id state.Identifier) (*runMetadata, error) {
 	val, err := m.r.HGetAll(ctx, m.kf.RunMetadata(ctx, id)).Result()
 	if err != nil {

--- a/pkg/execution/state/state.go
+++ b/pkg/execution/state/state.go
@@ -133,8 +133,25 @@ type State interface {
 
 // Loader allows loading of previously stored state based off of a given Identifier.
 type Loader interface {
+	// Load returns run state for the given identifier.
 	Load(ctx context.Context, i Identifier) (State, error)
+
+	// IsComplete returns whether the given identifier is complete, ie. the
+	// pending count in the identifier's metadata is zero.
+	IsComplete(ctx context.Context, i Identifier) (complete bool, err error)
 }
+
+/*
+// CompleteSubscriber allows users to subscribe to a particular identifier and block
+// until the identifier's pending count reaches zero.
+//
+// This is an optional interface which a state can implement using internal mechanisms
+// to watch keys.  The runner will check to see if the state store implements this interface;
+// if so, it will subscribe to be notified when the function completes.
+type CompleteSubscriber interface {
+	BlockUntilComplete(ctx context.Context, i Identifier) (complete bool, err error)
+}
+*/
 
 // Mutater mutates state for a given identifier, storing the state and returning
 // the new state.

--- a/pkg/execution/state/testharness/testharness.go
+++ b/pkg/execution/state/testharness/testharness.go
@@ -389,7 +389,7 @@ func checkMetadataStartedAt(t *testing.T, m state.Manager) {
 	require.NoError(t, err)
 	require.NotNil(t, reloaded)
 
-	require.EqualValues(t, s.Metadata().StartedAt, reloaded.Metadata().StartedAt)
+	require.EqualValues(t, s.Metadata().StartedAt.UTC(), reloaded.Metadata().StartedAt.UTC())
 }
 
 /*


### PR DESCRIPTION
This commit introduces a basic queue interface.  The interface allows
us to enqueue steps to run at a specific time, and to provide a function
which should run when items are dequeued.

We change the in-memory queue to use this interface, and will provide
other implementations of the interface such as celery, SQS, etc. in a
future PR.