### PR TITLE
Add `statusCode` fallback

### DIFF
--- a/pkg/execution/state/driver_response.go
+++ b/pkg/execution/state/driver_response.go
@@ -66,11 +66,17 @@ func (r DriverResponse) Retryable() bool {
 
 	status, ok := r.Output["status"]
 	if !ok {
-		// If actions don't return a status, we assume that they're
-		// always retryable.  We prefer that actions respond with a
-		// { "status": xxx, "body": ... } format to disable retries.
-		return true
+		// Fall back to statusCode for AWS Lambda compatibility in
+		// an attempt to use this field.
+		status, ok = r.Output["statusCode"]
+		if !ok {
+			// If actions don't return a status, we assume that they're
+			// always retryable.  We prefer that actions respond with a
+			// { "status": xxx, "body": ... } format to disable retries.
+			return true
+		}
 	}
+
 	switch v := status.(type) {
 	case float64:
 		if int(v) > 499 {

--- a/pkg/execution/state/driver_response_test.go
+++ b/pkg/execution/state/driver_response_test.go
@@ -78,6 +78,17 @@ func TestDriverResponseRetryable(t *testing.T) {
 			expected: false,
 		},
 		{
+			name: "4xx status in statusCode",
+			r: DriverResponse{
+				Output: map[string]interface{}{
+					"hi":         "my g",
+					"statusCode": 401,
+				},
+				Err: fmt.Errorf("some err"),
+			},
+			expected: false,
+		},
+		{
 			name: "499 status",
 			r: DriverResponse{
 				Output: map[string]interface{}{
@@ -102,6 +113,17 @@ func TestDriverResponseRetryable(t *testing.T) {
 				Output: map[string]interface{}{
 					"hi":     "my g",
 					"status": 500,
+				},
+				Err: fmt.Errorf("some err"),
+			},
+			expected: true,
+		},
+		{
+			name: "5xx statusCode",
+			r: DriverResponse{
+				Output: map[string]interface{}{
+					"hi":         "my g",
+					"statusCode": 500,
 				},
 				Err: fmt.Errorf("some err"),
 			},


### PR DESCRIPTION
Fixes #116 by falling back to `statusCode` when checking retryable statuses.